### PR TITLE
Add external IDs + namespaces to app users

### DIFF
--- a/services/application/src/actions/user/external-id.js
+++ b/services/application/src/actions/user/external-id.js
@@ -1,0 +1,33 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { isObject } = require('@base-cms/utils');
+const AppUser = require('../../mongodb/models/app-user');
+const EntityID = require('../../entity-id/id');
+
+module.exports = {
+  add: async ({
+    applicationId,
+    userId,
+    identifier,
+    namespace,
+  } = {}) => {
+    if (!applicationId) throw createRequiredParamError('applicationId');
+    if (!userId) throw createRequiredParamError('userId');
+    if (!isObject(identifier)) throw createRequiredParamError('identifier');
+    if (!isObject(namespace)) throw createRequiredParamError('namespace');
+    const user = await AppUser.findByIdForApp(userId, applicationId);
+    if (!user) throw createError(404, `No user was found for '${userId}'`);
+
+    const externalId = new EntityID(identifier, namespace);
+    const id = externalId.toString();
+
+    // external ID already set. do nothing and return user.
+    if (user.externalIds.some(({ _id }) => _id === id)) return user;
+    user.externalIds.push({
+      _id: id,
+      identifier: externalId.identifier,
+      namespace: externalId.namespace,
+    });
+    return user.save();
+  },
+};

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -7,6 +7,7 @@ const {
 } = require('@identity-x/utils').actions;
 const { createRequiredParamError } = require('@base-cms/micro').service;
 const create = require('./create');
+const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
 const login = require('./login');
 const logout = require('./logout');
@@ -22,6 +23,7 @@ const AppUser = require('../../mongodb/models/app-user');
 
 module.exports = {
   create,
+  externalId,
   findByEmail,
   findById: params => findById(AppUser, params),
   listForApp: params => listForApp(AppUser, params),

--- a/services/application/src/entity-id/format-value.js
+++ b/services/application/src/entity-id/format-value.js
@@ -1,0 +1,7 @@
+module.exports = (v) => {
+  if (!v) return null;
+  const str = `${v}`.trim();
+  if (!str || str === '_') return null;
+  if (/[.*~]/.test(v)) throw new Error('An invalid namespace character was encountered.');
+  return v;
+};

--- a/services/application/src/entity-id/id.js
+++ b/services/application/src/entity-id/id.js
@@ -1,0 +1,43 @@
+const Identifier = require('./identifier');
+const Namespace = require('./namespace');
+
+class EntityID {
+  /**
+   *
+   * @param {object|string|Identifier} identifier
+   * @param {object|string|Namespace} namespace
+   */
+  constructor(identifier, namespace) {
+    this.identifier = Identifier.make(identifier);
+    this.namespace = Namespace.make(namespace);
+  }
+
+  /**
+   *
+   */
+  toString() {
+    const { identifier, namespace } = this;
+    return [namespace, identifier].map(v => `${v}`).join('*');
+  }
+
+  /**
+   *
+   */
+  static parse(str) {
+    if (!str) throw new Error('Unable to parse entity ID: no value provided.');
+    const [namespace, identifier] = str.split('*');
+    return new EntityID(identifier, namespace);
+  }
+
+  /**
+   *
+   */
+  static make(value) {
+    if (!value) throw new Error('Unable to make entity ID: no value was provided.');
+    if (value instanceof EntityID) return value;
+    if (typeof value === 'string') return EntityID.parse(value);
+    return new EntityID(value.identifier, value.namespace);
+  }
+}
+
+module.exports = EntityID;

--- a/services/application/src/entity-id/identifier.js
+++ b/services/application/src/entity-id/identifier.js
@@ -1,0 +1,41 @@
+const formatValue = require('./format-value');
+
+class Identifier {
+  /**
+   *
+   * @param {object} identifier
+   * @param {string} identifier.value
+   * @param {string} [identifier.type]
+   */
+  constructor({ value, type } = {}) {
+    this.value = formatValue(value);
+    this.type = formatValue(type);
+    if (!this.value) throw new Error('The identifier `value` is required.');
+  }
+
+  /**
+   *
+   */
+  toString() {
+    const { value, type } = this;
+    return [value, type].filter(v => v).join('~');
+  }
+
+  /**
+   *
+   */
+  static parse(str) {
+    if (!str) throw new Error('Unable to parse entity identifier: no value provided.');
+    const [value, type] = `${str}`.trim().split('~');
+    return new Identifier({ value, type });
+  }
+
+  static make(value) {
+    if (!value) throw new Error('Unable to make entity identifier: no value was provided.');
+    if (value instanceof Identifier) return value;
+    if (typeof value === 'string') return Identifier.parse(value);
+    return new Identifier(value);
+  }
+}
+
+module.exports = Identifier;

--- a/services/application/src/entity-id/namespace.js
+++ b/services/application/src/entity-id/namespace.js
@@ -1,0 +1,49 @@
+const formatValue = require('./format-value');
+
+class Namespace {
+  /**
+   * Invalid characters: `.` `*` `~`
+   *
+   * Falsy values and `_` will be treated as `null`
+   *
+   * @param {object} namespace
+   * @param {string} [namespace.provider]
+   * @param {string} [namespace.tenant]
+   * @param {string} namespace.type
+   */
+  constructor({ provider, tenant, type } = {}) {
+    this.provider = formatValue(provider);
+    this.tenant = formatValue(tenant);
+    this.type = formatValue(type);
+    if (!this.type) throw new Error('The entity namespace `type` is required.');
+  }
+
+  /**
+   *
+   */
+  toString() {
+    const { provider, tenant, type } = this;
+    return [provider, tenant, type].map(v => v || '_').join('.');
+  }
+
+  /**
+   *
+   */
+  static parse(str) {
+    if (!str) throw new Error('Unable to parse entity namespace: no value provided.');
+    const [provider, tenant, type] = str.split('.');
+    return new Namespace({ provider, tenant, type });
+  }
+
+  /**
+   *
+   */
+  static make(value) {
+    if (!value) throw new Error('Unable to make entity namespace: no value was provided.');
+    if (value instanceof Namespace) return value;
+    if (typeof value === 'string') return Namespace.parse(value);
+    return new Namespace(value);
+  }
+}
+
+module.exports = Namespace;

--- a/services/application/src/mongodb/schema/app-user.js
+++ b/services/application/src/mongodb/schema/app-user.js
@@ -41,6 +41,46 @@ const customSelectFieldAnswerSchema = new Schema({
   },
 });
 
+const externalIdentifierSchema = new Schema({
+  _id: false,
+  value: {
+    type: String,
+    required: true,
+  },
+  type: {
+    type: String,
+  },
+});
+
+const externalNamespaceSchema = new Schema({
+  _id: false,
+  provider: {
+    type: String,
+  },
+  tenant: {
+    type: String,
+  },
+  type: {
+    type: String,
+    required: true,
+  },
+});
+
+const externalIdSchema = new Schema({
+  _id: {
+    type: String,
+    required: true,
+  },
+  identifier: {
+    type: externalIdentifierSchema,
+    required: true,
+  },
+  namespace: {
+    type: externalNamespaceSchema,
+    required: true,
+  },
+});
+
 const schema = new Schema({
   email: {
     type: String,
@@ -118,6 +158,10 @@ const schema = new Schema({
   },
   customSelectFieldAnswers: {
     type: [customSelectFieldAnswerSchema],
+    default: () => [],
+  },
+  externalIds: {
+    type: [externalIdSchema],
     default: () => [],
   },
 }, { timestamps: true });

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -29,6 +29,8 @@ extend type Mutation {
 
   "Sets field data to an unverified app user only. Is used for collecting user info before a login link is sent/used."
   setAppUserUnverifiedData(input: SetAppUserUnverifiedDataMutationInput!): AppUser! @requiresApp # must be public
+  "Adds an external identifier (with namespace) to an app user."
+  addAppUserExternalId(input: SetAppUserExternalIdMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
 }
 
 enum AppUserSortField {
@@ -81,8 +83,27 @@ type AppUser {
   regionalConsentAnswers: [AppUserRegionalConsentAnswer!]! @projection
   "Shows all answers to custom select questions. By default this will include all questions, even if the user has not answered."
   customSelectFieldAnswers(input: AppUserCustomSelectFieldAnswersInput = {}): [AppUserCustomSelectFieldAnswer!]! @projection
+  "Lists all external IDs + namespaces associated with this user."
+  externalIds: [AppUserExternalEntityId!]! @projection
   createdAt: Date @projection
   updatedAt: Date @projection
+}
+
+type AppUserExternalEntityId {
+  id: String!
+  identifier: AppUserExternalIdentifier!
+  namespace: AppUserExternalNamespace!
+}
+
+type AppUserExternalIdentifier {
+  value: String!
+  type: String
+}
+
+type AppUserExternalNamespace {
+  provider: String
+  tenant: String
+  type: String!
 }
 
 type AppUserRegionalConsentAnswer {
@@ -210,6 +231,31 @@ input SetAppUserBannedMutationInput {
   id: String!
   "Whether the user will be banned or not."
   value: Boolean!
+}
+
+input SetAppUserExternalIdMutationInput {
+  "The user ID to set the external ID to."
+  userId: String!
+  "The external identifier input."
+  identifier: AppUserExternalIdentifierInput!
+  "The external namespace input."
+  namespace: AppUserExternalNamespaceInput!
+}
+
+input AppUserExternalIdentifierInput {
+  "The external identifier value."
+  value: String!
+  "The (optiona) external identifier type - for distinguishing between different types of IDs."
+  type: String
+}
+
+input AppUserExternalNamespaceInput {
+  "The (optional) namespace provider."
+  provider: String
+  "The (optional) namespace tenant."
+  tenant: String
+  "The namespace model type."
+  type: String!
 }
 
 input SetAppUserRegionalConsentMutationInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -11,6 +11,10 @@ module.exports = {
     application: (_, __, { app }) => applicationService.request('findById', { id: app.getId() }),
   },
 
+  AppUserExternalEntityId: {
+    id: entity => entity._id,
+  },
+
   AppUser: {
     id: user => user._id,
     accessLevels: ({ accessLevelIds }) => {
@@ -164,6 +168,20 @@ module.exports = {
   },
 
   Mutation: {
+    /**
+     *
+     */
+    addAppUserExternalId: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const { userId, identifier, namespace } = input;
+      return applicationService.request('user.externalId.add', {
+        applicationId,
+        userId,
+        identifier,
+        namespace,
+      });
+    },
+
     /**
      *
      */

--- a/services/manage/app/router.js
+++ b/services/manage/app/router.js
@@ -54,6 +54,7 @@ Router.map(function() {
               this.route('create');
               this.route('edit', { path: ':email' }, function() {
                 this.route('custom-select-fields');
+                this.route('external-ids');
               });
             });
             this.route('comments', function() {

--- a/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/external-ids.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/external-ids.js
@@ -1,0 +1,33 @@
+import Route from '@ember/routing/route';
+import AppQueryMixin from '@identity-x/manage/mixins/app-query';
+import gql from 'graphql-tag';
+
+const query = gql`
+  query AppUsersEditExternalIds($input: AppUserQueryInput!) {
+    appUser(input: $input) {
+      id
+      email
+      externalIds {
+        id
+        identifier {
+          value
+          type
+        }
+        namespace {
+          provider
+          tenant
+          type
+        }
+      }
+    }
+  }
+`;
+
+export default Route.extend(AppQueryMixin, {
+  model() {
+    const { email } = this.modelFor('manage.orgs.view.apps.view.users.edit');
+    const input = { email };
+    const variables = { input };
+    return this.query({ query, variables, fetchPolicy: 'network-only' }, 'appUser');
+  },
+});

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
@@ -11,6 +11,11 @@
           Custom Fields
         {{/link-to}}
       </li>
+      <li class="nav-item">
+        {{#link-to "manage.orgs.view.apps.view.users.edit.external-ids" class="nav-link"}}
+          External IDs
+        {{/link-to}}
+      </li>
     </ul>
     <button
       type="button"

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/external-ids.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/external-ids.hbs
@@ -1,0 +1,34 @@
+<BsModal::Body>
+  <div class="row">
+    <div class="col table-responsive">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>Provider</th>
+            <th>Tenant</th>
+            <th>Entity Type</th>
+            <th>ID</th>
+            <th>ID Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each this.model.externalIds as |ent|}}
+            <tr>
+              <td>{{ ent.namespace.provider }}</td>
+              <td>{{ ent.namespace.tenant }}</td>
+              <td>{{ ent.namespace.type }}</td>
+              <td>{{ ent.identifier.value }}</td>
+              <td>{{ ent.identifier.type }}</td>
+            </tr>
+          {{else}}
+            <tr>
+              <td colspan="5" class="text-muted">
+                No external IDs have been assigned to this user
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</BsModal::Body>


### PR DESCRIPTION
Support multiple external identifiers, with namespaces, on app user objects. These can be added via the `addAppUserExternalId` mutation and are currently read-only in the management interface:

![image](https://user-images.githubusercontent.com/3289485/114213829-20ec5480-9929-11eb-85c5-1ad9a2dfaa29.png)
