### PR TITLE
Add support for authenticating users via API tokens

### DIFF
--- a/services/graphql/src/graphql/definitions/user.js
+++ b/services/graphql/src/graphql/definitions/user.js
@@ -10,6 +10,7 @@ extend type Query {
 }
 
 extend type Mutation {
+  createActiveUserApiToken: String! @requiresAuth
   registerNewUser(input: RegisterNewUserMutationInput!): UserRegistration!
   inviteUserToOrg(input: InviteUserToOrgMutationInput!): String @requiresOrgRole(roles: [Owner, Administrator])
   acceptOrgInvite(input: AcceptOrgInviteMutationInput!): String @requiresAuth

--- a/services/graphql/src/graphql/resolvers/user.js
+++ b/services/graphql/src/graphql/resolvers/user.js
@@ -129,6 +129,14 @@ module.exports = {
     /**
      *
      */
+    createActiveUserApiToken: (_, __, { user }) => {
+      const email = user.get('email');
+      return userService.request('createApiToken', { email });
+    },
+
+    /**
+     *
+     */
     updateUserProfile: (_, { input }, { user }) => {
       const { givenName, familyName, photoURL } = input;
       const payload = { givenName, familyName, photoURL };

--- a/services/token/src/actions/create.js
+++ b/services/token/src/actions/create.js
@@ -1,8 +1,7 @@
-const jwt = require('jsonwebtoken');
 const uuid = require('uuid/v4');
 const { createRequiredParamError } = require('@base-cms/micro').service;
-const { TOKEN_SECRET } = require('../env');
 const Token = require('../mongodb/models/token');
+const sign = require('./sign');
 
 /**
  * Creates an encoded JWT for the provided payload.
@@ -44,7 +43,7 @@ module.exports = async ({
     ...payload,
     ...initial,
   };
-  const token = jwt.sign(toSign, TOKEN_SECRET);
+  const token = sign({ payload: toSign });
   await Token.create({
     _id: jti,
     sub,

--- a/services/token/src/actions/index.js
+++ b/services/token/src/actions/index.js
@@ -1,9 +1,11 @@
 const create = require('./create');
 const invalidate = require('./invalidate');
+const sign = require('./sign');
 const verify = require('./verify');
 
 module.exports = {
   create,
   invalidate,
+  sign,
   verify,
 };

--- a/services/token/src/actions/index.js
+++ b/services/token/src/actions/index.js
@@ -1,3 +1,4 @@
+const Token = require('../mongodb/models/token');
 const create = require('./create');
 const invalidate = require('./invalidate');
 const sign = require('./sign');
@@ -5,6 +6,7 @@ const verify = require('./verify');
 
 module.exports = {
   create,
+  findOne: ({ query, fields }) => Token.findOne(query, fields),
   invalidate,
   sign,
   verify,

--- a/services/token/src/actions/sign.js
+++ b/services/token/src/actions/sign.js
@@ -1,0 +1,8 @@
+const jwt = require('jsonwebtoken');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { TOKEN_SECRET } = require('../env');
+
+module.exports = async ({ payload } = {}) => {
+  if (!payload) throw createRequiredParamError('payload');
+  return jwt.sign(payload, TOKEN_SECRET);
+};

--- a/services/user/src/actions/create-api-token.js
+++ b/services/user/src/actions/create-api-token.js
@@ -1,0 +1,26 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+
+const findByEmail = require('./find-by-email');
+
+const sub = 'user-api-token';
+
+module.exports = async ({ email } = {}) => {
+  if (!email) throw createRequiredParamError('email');
+  const user = await findByEmail({ email, fields: ['id', 'email'] });
+  if (!user) throw createError(404, `No user was found for '${email}'`);
+
+  const existingToken = await tokenService.request('findOne', {
+    query: { sub, 'payload.aud': email },
+  });
+  if (existingToken) {
+    // re-use existing api tokens.
+    return tokenService.request('sign', { payload: existingToken.payload });
+  }
+  const { token } = await tokenService.request('create', {
+    payload: { aud: email },
+    sub: 'user-api-token',
+  });
+  return token;
+};

--- a/services/user/src/actions/create-api-token.js
+++ b/services/user/src/actions/create-api-token.js
@@ -20,7 +20,7 @@ module.exports = async ({ email } = {}) => {
   }
   const { token } = await tokenService.request('create', {
     payload: { aud: email },
-    sub: 'user-api-token',
+    sub,
   });
   return token;
 };

--- a/services/user/src/actions/index.js
+++ b/services/user/src/actions/index.js
@@ -1,4 +1,5 @@
 const create = require('./create');
+const createApiToken = require('./create-api-token');
 const findByEmail = require('./find-by-email');
 const login = require('./login');
 const logout = require('./logout');
@@ -8,6 +9,7 @@ const verifyAuth = require('./verify-auth');
 
 module.exports = {
   create,
+  createApiToken,
   findByEmail,
   login,
   logout,

--- a/services/user/src/actions/index.js
+++ b/services/user/src/actions/index.js
@@ -5,6 +5,7 @@ const login = require('./login');
 const logout = require('./logout');
 const sendLoginLink = require('./send-login-link');
 const update = require('./update');
+const verifyApiToken = require('./verify-api-token');
 const verifyAuth = require('./verify-auth');
 
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   logout,
   sendLoginLink,
   update,
+  verifyApiToken,
   verifyAuth,
 };

--- a/services/user/src/actions/verify-api-token.js
+++ b/services/user/src/actions/verify-api-token.js
@@ -1,0 +1,22 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+
+const findByEmail = require('./find-by-email');
+
+module.exports = async ({ token, fields } = {}) => {
+  if (!token) throw createRequiredParamError('token');
+  try {
+    const verified = await tokenService.request('verify', { sub: 'user-api-token', token });
+    const { aud: email } = verified;
+    if (!email) throw createError(400, 'No email address was provided in the token payload');
+
+    const user = await findByEmail({ email, fields });
+    if (!user) throw createError(404, `No user was found for '${email}'`);
+    if (user.email !== email) throw createError(401, 'The user email does not match the token email.');
+
+    return { user, token: verified };
+  } catch (e) {
+    throw createError(401, e.message);
+  }
+};


### PR DESCRIPTION
One-time API tokens can be issued by the active user (for the active user only) that can be used in place of a "standard" auth token. The same user roles and permissions still apply. Useful for authenticating machine access.