### PR TITLE
Return ISO alpha-3 code with locale country

### DIFF
--- a/services/graphql/src/graphql/definitions/locale.js
+++ b/services/graphql/src/graphql/definitions/locale.js
@@ -27,6 +27,8 @@ enum LocaleCountriesWithRegions {
 type LocaleCountry {
   "The ISO-3166 Alpha2 country code"
   id: String!
+  "The ISO-3166 Alpha3 country code"
+  alpha3: String!
   "The country name"
   name: String!
   "The country's flag emoji"

--- a/services/graphql/src/graphql/definitions/locale.js
+++ b/services/graphql/src/graphql/definitions/locale.js
@@ -3,7 +3,11 @@ const gql = require('graphql-tag');
 module.exports = gql`
 
 extend type Query {
+  "Retrieve a single country from a country code."
+  localeCountry(input: LocaleCountryQueryInput!): LocaleCountry
+  "Retrieves all registered countries."
   localeCountries(input: LocaleCountriesQueryInput = {}): [LocaleCountry!]!
+  "Retrieves all registered regions for a provided country."
   localeRegions(input: LocaleRegionsQueryInput = {}): [LocaleRegion!]!
 }
 
@@ -46,6 +50,15 @@ type LocaleRegion {
   category: LocaleRegionCategory!
   "The country information"
   country: LocaleCountry!
+}
+
+input LocaleCountryQueryInput {
+  "The ISO-3166 Alpha2 country code to query."
+  code: String!
+  "The language to return."
+  lang: String = "en"
+  "Whether to include the country flag emoji."
+  withFlag: Boolean = true
 }
 
 input LocaleCountriesQueryInput {

--- a/services/graphql/src/graphql/resolvers/locale.js
+++ b/services/graphql/src/graphql/resolvers/locale.js
@@ -28,6 +28,14 @@ module.exports = {
     /**
      *
      */
+    localeCountry: (_, { input }) => {
+      const { code, lang, withFlag } = input;
+      return localeService.request('country.asObject', { code, lang, withFlag });
+    },
+
+    /**
+     *
+     */
     localeRegions: (_, { input }) => {
       const { countryCodes, categories } = input;
       return localeService.request('region.getAll', { countryCodes, categories });

--- a/services/locale/src/actions/country/as-object.js
+++ b/services/locale/src/actions/country/as-object.js
@@ -10,6 +10,7 @@ module.exports = ({ code, lang = 'en', withFlag = true }) => {
   if (!alpha2) return null;
   const obj = {
     code: alpha2,
+    alpha3: countries.getAlpha3Code(name, lang),
     name: countries.getName(code, lang),
   };
   if (withFlag) obj.flag = getEmoji(alpha2);

--- a/services/locale/src/actions/country/get-all.js
+++ b/services/locale/src/actions/country/get-all.js
@@ -31,7 +31,7 @@ module.exports = ({
 
   const ordered = { ...top, ...sorted };
   return Object.keys(ordered).map((code) => {
-    const obj = { code, name: ordered[code] };
+    const obj = { code, name: ordered[code], alpha3: countries.getAlpha3Code(ordered[code], lang) };
     if (!withFlag) return obj;
     obj.flag = getEmoji(code);
     return obj;


### PR DESCRIPTION
Some systems (e.g. Omeda) require country codes to be in ISO alpha-3 format.

In addition, add support for retrieving a single country by alpha-2 code via the `localeCountry` query