### PR TITLE
Custom text field support

### DIFF
--- a/services/application/src/actions/field/index.js
+++ b/services/application/src/actions/field/index.js
@@ -12,17 +12,20 @@ const userSelectAnswers = require('./user-select-answers');
 const Field = require('../../mongodb/models/field');
 const SelectField = require('../../mongodb/models/field/select');
 const BooleanField = require('../../mongodb/models/field/boolean');
+const TextField = require('../../mongodb/models/field/text');
 
 module.exports = {
   create,
   findById: ({ id, type, fields }) => {
-    const supportedTypes = ['select', 'boolean'];
+    const supportedTypes = ['select', 'boolean', 'text'];
     if (!supportedTypes.includes(type)) throw createParamError('type', type, supportedTypes);
     switch (type) {
       case 'boolean':
         return findById(BooleanField, { id, fields });
-      default:
+      case 'select':
         return findById(SelectField, { id, fields });
+      default:
+        return findById(TextField, { id, fields });
     }
   },
   listForApp: params => listForApp(Field, params),

--- a/services/application/src/actions/field/index.js
+++ b/services/application/src/actions/field/index.js
@@ -8,6 +8,7 @@ const create = require('./create');
 const updateOne = require('./update-one');
 const userBooleanAnswers = require('./user-boolean-answers');
 const userSelectAnswers = require('./user-select-answers');
+const userTextAnswers = require('./user-text-answers');
 
 const Field = require('../../mongodb/models/field');
 const SelectField = require('../../mongodb/models/field/select');
@@ -33,4 +34,5 @@ module.exports = {
   updateOne,
   userBooleanAnswers,
   userSelectAnswers,
+  userTextAnswers,
 };

--- a/services/application/src/actions/field/update-one.js
+++ b/services/application/src/actions/field/update-one.js
@@ -5,6 +5,7 @@ const { handleError } = require('@identity-x/utils').mongoose;
 const { Application } = require('../../mongodb/models');
 const BooleanField = require('../../mongodb/models/field/boolean');
 const SelectField = require('../../mongodb/models/field/select');
+const TextField = require('../../mongodb/models/field/text');
 const prepareExternalId = require('./utils/prepare-external-id');
 
 const updateSelect = async ({
@@ -93,6 +94,35 @@ const updateBoolean = async ({
   await boolean.save();
   return boolean;
 };
+const updateText = async ({
+  id,
+  application,
+  payload,
+} = {}) => {
+  const text = await TextField.findByIdForApp(id, application._id);
+  if (!text) throw createError(404, `No text field was found for '${id}'`);
+
+  const {
+    name,
+    label,
+    required,
+    active,
+    externalId: eid,
+  } = payload;
+
+  const externalId = prepareExternalId(eid);
+
+  text.set({
+    name,
+    label,
+    required,
+    active,
+    externalId,
+  });
+
+  await text.save();
+  return text;
+};
 
 module.exports = async ({
   id,
@@ -101,20 +131,21 @@ module.exports = async ({
   payload = {},
 } = {}) => {
   if (!id) throw createRequiredParamError('id');
-  const supportedTypes = ['select', 'boolean'];
+  const supportedTypes = ['select', 'boolean', 'text'];
   if (!supportedTypes.includes(type)) throw createParamError('type', type, supportedTypes);
   if (!applicationId) throw createRequiredParamError('applicationId');
 
   const application = await Application.findById(applicationId, ['id']);
   if (!application) throw createError(404, `No application was found for '${applicationId}'`);
 
-  // for now, only select field types are supported.
   try {
     switch (type) {
       case 'boolean':
         return updateBoolean({ id, application, payload });
-      default:
+      case 'select':
         return updateSelect({ id, application, payload });
+      default:
+        return updateText({ id, application, payload });
     }
   } catch (e) {
     throw handleError(createError, e);

--- a/services/application/src/actions/field/user-text-answers.js
+++ b/services/application/src/actions/field/user-text-answers.js
@@ -1,0 +1,45 @@
+const { Sort } = require('@identity-x/pagination');
+const TextField = require('../../mongodb/models/field/text');
+
+const { isArray } = Array;
+
+module.exports = async ({
+  applicationId,
+  fieldIds,
+  customTextFieldAnswers,
+  onlyAnswered,
+  onlyActive,
+  sort,
+} = {}) => {
+  const $sort = new Sort(sort);
+  const fieldQuery = {
+    applicationId,
+    ...(isArray(fieldIds) && fieldIds.length && { _id: { $in: fieldIds } }),
+    ...(onlyActive && { active: { $ne: false } }),
+  };
+  const fields = await TextField.find(fieldQuery, {}, { sort: $sort.value });
+  // return nothing when no custom booleans are found.
+  if (!fields.length) return [];
+
+  // ensure answers are an array
+  const customFieldAnswers = !isArray(customTextFieldAnswers)
+  || !customTextFieldAnswers.length
+    ? []
+    : customTextFieldAnswers;
+
+
+  // return nothing when no answers are found and only answered questions have been requested.
+  if (onlyAnswered && !customFieldAnswers.length) return [];
+
+  const mapped = fields.map((field) => {
+    const fieldAnswer = customFieldAnswers.find(answer => `${answer._id}` === `${field._id}`);
+    const answer = fieldAnswer ? fieldAnswer.value : null;
+    return {
+      id: field._id,
+      field,
+      hasAnswered: Boolean(fieldAnswer),
+      answer,
+    };
+  });
+  return onlyAnswered ? mapped.filter(field => field.hasAnswered) : mapped;
+};

--- a/services/application/src/actions/field/user-text-answers.js
+++ b/services/application/src/actions/field/user-text-answers.js
@@ -33,12 +33,12 @@ module.exports = async ({
 
   const mapped = fields.map((field) => {
     const fieldAnswer = customFieldAnswers.find(answer => `${answer._id}` === `${field._id}`);
-    const answer = fieldAnswer ? fieldAnswer.value : null;
+    const value = fieldAnswer ? fieldAnswer.value : null;
     return {
       id: field._id,
       field,
       hasAnswered: Boolean(fieldAnswer),
-      answer,
+      value,
     };
   });
   return onlyAnswered ? mapped.filter(field => field.hasAnswered) : mapped;

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -25,6 +25,7 @@ const setUnverifiedData = require('./set-unverified-data');
 const updateCustomAttributes = require('./update-custom-attributes');
 const updateCustomBooleanAnswers = require('./update-custom-boolean-answers');
 const updateCustomSelectAnswers = require('./update-custom-select-answers');
+const updateCustomTextAnswers = require('./update-custom-text-answers');
 const updateOne = require('./update-one');
 const verifyAuth = require('./verify-auth');
 
@@ -55,6 +56,7 @@ module.exports = {
   updateCustomAttributes,
   updateCustomBooleanAnswers,
   updateCustomSelectAnswers,
+  updateCustomTextAnswers,
   updateOne,
   verifyAuth,
   setLastSeen: async ({ id }) => {

--- a/services/application/src/actions/user/update-custom-text-answers.js
+++ b/services/application/src/actions/user/update-custom-text-answers.js
@@ -1,0 +1,54 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { handleError } = require('@identity-x/utils').mongoose;
+
+const { AppUser } = require('../../mongodb/models');
+
+const { isArray } = Array;
+
+module.exports = async ({
+  id,
+  applicationId,
+  answers,
+  profileLastVerifiedAt,
+} = {}) => {
+  if (!id) throw createRequiredParamError('id');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+
+  const user = await AppUser.findByIdForApp(id, applicationId);
+  if (!user) throw createError(404, `No user was found for '${id}'`);
+
+  // do not update user answers when passed answers are not an array
+  if (!isArray(answers)) return user;
+
+  // get all current answers as object { id, value }
+  const userObj = user.customTextFieldAnswers.reduce(
+    (obj, item) => ({ ...obj, [item._id]: item.value }), {},
+  );
+
+  // get new answers as object { id, value }
+  const newAnswers = answers.reduce(
+    (obj, item) => ({ ...obj, [item.fieldId]: item.value }), {},
+  );
+
+  // merge new and old ansers to account for old non active answers
+  const mergedAnswers = { ...userObj, ...newAnswers };
+
+  // convert merged answers into valid array of { _id, value } answers
+  const toSet = Object.keys(mergedAnswers).map((key) => {
+    const obj = { _id: key, value: mergedAnswers[key] };
+    return obj;
+  });
+
+  user.set('customTextFieldAnswers', toSet);
+  if (profileLastVerifiedAt) {
+    user.set('profileLastVerifiedAt', profileLastVerifiedAt);
+    user.set('forceProfileReVerification', false);
+  }
+  try {
+    await user.save();
+    return user;
+  } catch (e) {
+    throw handleError(createError, e);
+  }
+};

--- a/services/application/src/mongodb/models/field/text.js
+++ b/services/application/src/mongodb/models/field/text.js
@@ -1,0 +1,4 @@
+const Field = require('./index');
+const schema = require('../../schema/field/text');
+
+module.exports = Field.discriminator('field-text', schema, 'text');

--- a/services/application/src/mongodb/models/index.js
+++ b/services/application/src/mongodb/models/index.js
@@ -5,7 +5,9 @@ const AppUserLogin = require('./app-user-login');
 const Segment = require('./segment');
 const Comment = require('./comment');
 const CommentStream = require('./comment-stream');
+const FieldBoolean = require('./field/boolean');
 const FieldSelect = require('./field/select');
+const FieldText = require('./field/text');
 const Team = require('./team');
 
 module.exports = {
@@ -16,6 +18,8 @@ module.exports = {
   Segment,
   Comment,
   CommentStream,
+  FieldBoolean,
   FieldSelect,
+  FieldText,
   Team,
 };

--- a/services/application/src/mongodb/schema/app-user.js
+++ b/services/application/src/mongodb/schema/app-user.js
@@ -72,6 +72,20 @@ const customSelectFieldAnswerSchema = new Schema({
   },
 });
 
+/**
+ * The built-in `_id` field of this sub-document represents
+ * the custom text field id.
+ */
+const customTextFieldAnswerSchema = new Schema({
+  /**
+   * The custom text field answer.
+   */
+  value: {
+    type: Schema.Types.String,
+    trim: true,
+  },
+});
+
 const schema = new Schema({
   email: {
     type: String,
@@ -183,6 +197,10 @@ const schema = new Schema({
   },
   customSelectFieldAnswers: {
     type: [customSelectFieldAnswerSchema],
+    default: () => [],
+  },
+  customTextFieldAnswers: {
+    type: [customTextFieldAnswerSchema],
     default: () => [],
   },
   customAttributes: {

--- a/services/application/src/mongodb/schema/field/text.js
+++ b/services/application/src/mongodb/schema/field/text.js
@@ -1,0 +1,5 @@
+const { Schema } = require('mongoose');
+
+const schema = new Schema({});
+
+module.exports = schema;

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -37,6 +37,8 @@ extend type Mutation {
   updateOwnAppUserCustomBooleanAnswers(input: UpdateOwnAppUserCustomBooleanAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
   updateAppUserCustomSelectAnswers(input: UpdateAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
   updateOwnAppUserCustomSelectAnswers(input: UpdateOwnAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
+  updateAppUserCustomTextAnswers(input: UpdateAppUserCustomTextAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
+  updateOwnAppUserCustomTextAnswers(input: UpdateOwnAppUserCustomTextAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
 
   "Sets field data to an unverified app user only. Is used for collecting user info before a login link is sent/used."
   setAppUserUnverifiedData(input: SetAppUserUnverifiedDataMutationInput!): AppUser! @requiresApp # must be public
@@ -119,6 +121,8 @@ type AppUser {
   customSelectFieldAnswers(input: AppUserCustomSelectFieldAnswersInput = {}): [AppUserCustomSelectFieldAnswer!]! @projection
   "Shows all custom attributes stored on the user."
   customAttributes: JSONObject! @projection
+  "Shows all answers to custom text questions. By default this will include all questions, even if the user has not answered."
+  customTextFieldAnswers(input: AppUserCustomTextFieldAnswersInput = {}): [AppUserCustomTextFieldAnswer!]! @projection
   "Lists all external IDs + namespaces associated with this user."
   externalIds: [AppUserExternalEntityId!]! @projection
   createdAt: Date @projection
@@ -187,6 +191,17 @@ type SelectFieldOptionAnswer {
   externalIdentifier: String
 }
 
+type AppUserCustomTextFieldAnswer {
+  "The user-to-answer identifier."
+  id: String!
+  "The custom select field that was answered."
+  field: TextField!
+  "Whether the user has answered the question."
+  hasAnswered: Boolean!
+  "The answered field value. A null value signifies a non answer. It's up to the implementing components to account for this."
+  answer: String
+}
+
 type AppUserConnection @projectUsing(type: "AppUser") {
   totalCount: Int!
   edges: [AppUserEdge]!
@@ -230,6 +245,17 @@ input AppUserCustomBooleanFieldAnswersInput {
 }
 
 input AppUserCustomSelectFieldAnswersInput {
+  "Only return answers for the provided field IDs. An empty value will return all answers."
+  fieldIds: [String!] = []
+  "If true, will only return answers the user has set. Otherwise, all questions will be return, with empty answers where not set. This will also be filtered by the fieldIds input."
+  onlyAnswered: Boolean = false
+  "If true, will only return active questions. This will also be filtered by the fieldIds and onlyAnswered inputs."
+  onlyActive: Boolean = false
+  "Optionally sort by fields on the custom field."
+  sort: FieldInterfaceSortInput = {}
+}
+
+input AppUserCustomTextFieldAnswersInput {
   "Only return answers for the provided field IDs. An empty value will return all answers."
   fieldIds: [String!] = []
   "If true, will only return answers the user has set. Otherwise, all questions will be return, with empty answers where not set. This will also be filtered by the fieldIds input."
@@ -495,6 +521,18 @@ input UpdateOwnAppUserCustomSelectAnswersMutationInput {
   answers: [UpdateAppUserCustomSelectAnswer!]
 }
 
+input UpdateAppUserCustomTextAnswersMutationInput {
+  "The user id to update."
+  id: String!
+  "The answers to set/update. An empty array or null value will do nothing."
+  answers: [UpdateAppUserCustomTextAnswer!]
+}
+
+input UpdateOwnAppUserCustomTextAnswersMutationInput {
+  "The answers to set/update for the current user. An empty array or null value will do nothing."
+  answers: [UpdateAppUserCustomTextAnswer!]
+}
+
 input UpdateAppUserCustomBooleanAnswer {
   "The custom boolean field ID."
   fieldId: String!
@@ -513,6 +551,13 @@ input UpdateAppUserCustomSelectAnswer {
 
 input UpdateAppUserCustomSelectAnswerWriteInValue {
   optionId: String!
+  value: String
+}
+
+input UpdateAppUserCustomTextAnswer {
+  "The custom select field ID."
+  fieldId: String!
+  "The text value to store."
   value: String
 }
 

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -199,7 +199,7 @@ type AppUserCustomTextFieldAnswer {
   "Whether the user has answered the question."
   hasAnswered: Boolean!
   "The answered field value. A null value signifies a non answer. It's up to the implementing components to account for this."
-  answer: String
+  value: String
 }
 
 type AppUserConnection @projectUsing(type: "AppUser") {

--- a/services/graphql/src/graphql/definitions/field.js
+++ b/services/graphql/src/graphql/definitions/field.js
@@ -11,6 +11,8 @@ extend type Query {
   selectField(input: SelectFieldQueryInput!): SelectField
   "Finds a single boolean field by ID."
   booleanField(input: BooleanFieldQueryInput!): BooleanField
+  "Finds a single text field by ID."
+  textField(input: TextFieldQueryInput!): TextField
 }
 
 extend type Mutation {
@@ -22,6 +24,10 @@ extend type Mutation {
   createSelectField(input: CreateSelectFieldMutationInput!): SelectField! @requiresAppRole(roles: [Owner, Administrator, Member])
   "Updates an existing select field with the provided input."
   updateSelectField(input: UpdateSelectFieldMutationInput!): SelectField! @requiresAppRole(roles: [Owner, Administrator, Member])
+  "Creates a new text field for the current application context."
+  createTextField(input: CreateTextFieldMutationInput!): TextField! @requiresAppRole(roles: [Owner, Administrator, Member])
+  "Updates an existing text field with the provided input."
+  updateTextField(input: UpdateTextFieldMutationInput!): TextField! @requiresAppRole(roles: [Owner, Administrator, Member])
 }
 
 enum FieldValueTypeEnum {
@@ -184,6 +190,27 @@ type SelectFieldOptionGroup implements SelectFieldOptionChoice {
   optionIds: [String!]!
 }
 
+type TextField implements FieldInterface {
+  "The internal field ID."
+  id: String! @projection(localField: "_id")
+  "The field type."
+  type: String! @projection(localField: "_type")
+  "The internal name of the field."
+  name: String! @projection
+  "The user-facing field label. This is what will appear on a form."
+  label: String! @projection
+  "Whether the field is globally required."
+  required: Boolean! @projection
+  "Whether the field is currently active."
+  active: Boolean! @projection
+  "The date the field was created."
+  createdAt: Date! @projection
+  "The date the field was updated."
+  updatedAt: Date! @projection
+  "An external ID + namespaces associated with this custom field."
+  externalId: FieldInterfaceExternalEntityId @projection
+}
+
 input CreateBooleanFieldMutationInput {
   "The internal name of the field."
   name: String!
@@ -223,6 +250,19 @@ input CreateSelectFieldOptionInput {
   canWriteIn: Boolean = false
 }
 
+input CreateTextFieldMutationInput {
+  "The internal name of the field."
+  name: String!
+  "The user-facing field label. This is what will appear on a form."
+  label: String!
+  "Whether the field is globally required."
+  required: Boolean = false
+  "Whether the field is currently active."
+  active: Boolean = true
+  "The external namespace + ID for this field."
+  externalId: FieldInterfaceExternalIdMutationInput
+}
+
 input FieldInterfaceSortInput {
   field: FieldInterfaceSortField = id
   order: SortOrder = desc
@@ -247,6 +287,10 @@ input BooleanFieldQueryInput {
 }
 
 input SelectFieldQueryInput {
+  id: String!
+}
+
+input TextFieldQueryInput {
   id: String!
 }
 
@@ -345,6 +389,21 @@ input UpdateSelectFieldOptionGroupInput {
   index: Int = 0
   "The options in this group."
   optionIds: [String!]! = []
+}
+
+input UpdateTextFieldMutationInput {
+  "The select field identifier to update."
+  id: String!
+  "The internal name of the field."
+  name: String!
+  "The user-facing field label. This is what will appear on a form."
+  label: String!
+  "Whether the field is globally required."
+  required: Boolean = false
+  "Whether the field is currently active."
+  active: Boolean = true
+  "The external namespace + ID for this field."
+  externalId: FieldInterfaceExternalIdMutationInput
 }
 
 `;

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -120,6 +120,24 @@ module.exports = {
       });
     },
 
+    customTextFieldAnswers: async ({ customTextFieldAnswers }, { input }, { app }) => {
+      const {
+        fieldIds,
+        onlyAnswered,
+        onlyActive,
+        sort,
+      } = input;
+      const textFieldAnswers = await applicationService.request('field.userTextAnswers', {
+        applicationId: app.getId(),
+        fieldIds,
+        customTextFieldAnswers,
+        onlyAnswered,
+        onlyActive,
+        sort,
+      });
+      return textFieldAnswers;
+    },
+
     mustReVerifyProfile: ({ forceProfileReVerification, profileLastVerifiedAt }, _, { app }) => {
       if (forceProfileReVerification) return true; // verify flag has been hard set.
       const { appUserAllowedStaleDays } = app.org;
@@ -744,6 +762,34 @@ module.exports = {
       const applicationId = user.getAppId();
       const { answers } = input;
       return applicationService.request('user.updateCustomSelectAnswers', {
+        id,
+        applicationId,
+        answers,
+        profileLastVerifiedAt: new Date(),
+      });
+    },
+
+    /**
+     *
+     */
+    updateAppUserCustomTextAnswers: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const { id, answers } = input;
+      return applicationService.request('user.updateCustomTextAnswers', {
+        id,
+        applicationId,
+        answers,
+      });
+    },
+
+    /**
+     *
+     */
+    updateOwnAppUserCustomTextAnswers: (_, { input }, { user }) => {
+      const id = user.getId();
+      const applicationId = user.getAppId();
+      const { answers } = input;
+      return applicationService.request('user.updateCustomTextAnswers', {
         id,
         applicationId,
         answers,

--- a/services/graphql/src/graphql/resolvers/field.js
+++ b/services/graphql/src/graphql/resolvers/field.js
@@ -159,6 +159,21 @@ module.exports = {
   /**
    *
    */
+  TextField: {
+    /**
+     *
+     */
+    id: field => field._id,
+
+    /**
+     *
+     */
+    type: field => field._type,
+  },
+
+  /**
+   *
+   */
   Mutation: {
     /**
      *
@@ -217,6 +232,28 @@ module.exports = {
     /**
      *
      */
+    createTextField: (_, { input }, { app }) => {
+      const {
+        name,
+        label,
+        required,
+        active,
+        externalId,
+      } = input;
+      const applicationId = app.getId();
+      return applicationService.request('field.create', {
+        type: 'text',
+        applicationId,
+        payload: {
+          name,
+          label,
+          required,
+          active,
+          externalId,
+        },
+      });
+    },
+
     /**
      *
      */
@@ -251,9 +288,6 @@ module.exports = {
     /**
      *
      */
-    /**
-     *
-     */
     updateSelectField: (_, { input }, { app }) => {
       const applicationId = app.getId();
       const {
@@ -281,6 +315,33 @@ module.exports = {
           externalId,
           options,
           groups,
+        },
+      });
+    },
+
+    /**
+     *
+     */
+    updateTextField: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const {
+        id,
+        name,
+        label,
+        required,
+        active,
+        externalId,
+      } = input;
+      return applicationService.request('field.updateOne', {
+        id,
+        type: 'text',
+        applicationId,
+        payload: {
+          name,
+          label,
+          required,
+          active,
+          externalId,
         },
       });
     },
@@ -345,6 +406,15 @@ module.exports = {
       const { id } = input;
       const fields = typeProjection(info);
       return applicationService.request('field.findById', { id, type: 'select', fields });
+    },
+
+    /**
+     *
+     */
+    textField: (_, { input }, ctx, info) => {
+      const { id } = input;
+      const fields = typeProjection(info);
+      return applicationService.request('field.findById', { id, type: 'text', fields });
     },
   },
 };

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/fields/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/fields/create.js
@@ -22,6 +22,15 @@ const mutations = {
         }
       }`,
     fieldType: 'createBooleanField',
+  },
+  text: {
+    mutation: gql`
+      mutation AppTextFieldCreate($input: CreateTextFieldMutationInput!) {
+        createTextField(input: $input) {
+          id
+        }
+      }`,
+    fieldType: 'createTextField',
   }
 };
 

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/text.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/text.js
@@ -1,0 +1,70 @@
+import Controller from '@ember/controller';
+import ActionMixin from '@identity-x/manage/mixins/action-mixin';
+import AppQueryMixin from '@identity-x/manage/mixins/app-query';
+import gql from 'graphql-tag';
+import { inject } from '@ember/service';
+
+const mutation = gql`
+  mutation AppFieldEdit($input: UpdateTextFieldMutationInput!) {
+    updateTextField(input: $input) {
+      id
+      name
+      label
+      required
+      active
+      externalId {
+        id
+        namespace { provider tenant type }
+        identifier { value }
+      }
+    }
+  }
+`;
+
+export default Controller.extend(ActionMixin, AppQueryMixin, {
+  errorNotifier: inject(),
+
+  actions: {
+    async update(closeModal) {
+      try {
+        this.startAction();
+        const {
+          id,
+          name,
+          label,
+          required,
+          active,
+          externalId,
+        } = this.get('model');
+
+        const input = {
+          id,
+          name,
+          label,
+          required,
+          active,
+          externalId: {
+            ...(externalId && externalId.namespace && externalId.namespace.type && {
+              namespace: {
+                provider: externalId.namespace.provider,
+                tenant: externalId.namespace.tenant,
+                type: externalId.namespace.type,
+              },
+            }),
+            ...(externalId && externalId.identifier && externalId.identifier.value && {
+              identifier: { value: externalId.identifier.value },
+            }),
+          },
+        };
+        if (!Object.keys(input.externalId).length) delete input.externalId;
+        const variables = { input };
+        await this.mutate({ mutation, variables }, 'updateTextField');
+        await closeModal();
+      } catch (e) {
+        this.errorNotifier.show(e);
+      } finally {
+        this.endAction();
+      }
+    },
+  },
+});

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit.js
@@ -2,9 +2,19 @@ import Controller from '@ember/controller';
 import ActionMixin from '@identity-x/manage/mixins/action-mixin';
 import AppQueryMixin from '@identity-x/manage/mixins/app-query';
 import { inject } from '@ember/service';
+import { computed } from '@ember/object';
 
 export default Controller.extend(ActionMixin, AppQueryMixin, {
   router: inject(),
+
+  isCustomActive: computed('router.currentRouteName', function() {
+    return this.router.currentRouteName.includes('users.edit.custom-');
+  }),
+  customDropdownClasses: computed('isCustomActive', function() {
+    const classes = ['nav-link', 'dropdown-toggle'];
+    if (this.isCustomActive) classes.push('active');
+    return classes.join(' ');
+  }),
 
   actions: {
     returnToList() {

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-text-fields.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-text-fields.js
@@ -1,0 +1,43 @@
+import Controller from '@ember/controller';
+import ActionMixin from '@identity-x/manage/mixins/action-mixin';
+import AppQueryMixin from '@identity-x/manage/mixins/app-query';
+import gql from 'graphql-tag';
+import { inject } from '@ember/service';
+
+const mutation = gql`
+  mutation AppUserEditCustomTextFields($input: UpdateAppUserCustomTextAnswersMutationInput!) {
+    updateAppUserCustomTextAnswers(input: $input) {
+      id
+      customTextFieldAnswers {
+        id
+        value
+      }
+    }
+  }
+`;
+
+export default Controller.extend(ActionMixin, AppQueryMixin, {
+  errorNotifier: inject(),
+
+  actions: {
+    async save() {
+      try {
+        this.startAction();
+        const id = this.get('model.id');
+        const input = {
+          id,
+          answers: this.get('model.customTextFieldAnswers').map((answer) => {
+            const { value, field } = answer;
+            return { fieldId: field.id, value };
+          })
+        };
+        const variables = { input };
+        await this.mutate({ mutation, variables }, 'updateAppUserCustomTextAnswers');
+      } catch (e) {
+        this.errorNotifier.show(e);
+      } finally {
+        this.endAction();
+      }
+    },
+  },
+});

--- a/services/manage/app/router.js
+++ b/services/manage/app/router.js
@@ -60,6 +60,7 @@ Router.map(function() {
                 this.route('address-fields');
                 this.route('custom-boolean-fields');
                 this.route('custom-select-fields');
+                this.route('custom-text-fields');
                 this.route('external-ids');
               });
             });
@@ -71,6 +72,7 @@ Router.map(function() {
               this.route('edit', function() {
                 this.route('boolean', { path: 'boolean/:field_id' });
                 this.route('select', { path: 'select/:field_id' });
+                this.route('text', { path: 'text/:field_id' });
               });
             });
           });

--- a/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/text.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/text.js
@@ -1,0 +1,29 @@
+import Route from '@ember/routing/route';
+import AppQueryMixin from '@identity-x/manage/mixins/app-query';
+import gql from 'graphql-tag';
+
+const query = gql`
+  query AppFieldsEdit($input: TextFieldQueryInput!) {
+    textField(input: $input) {
+      id
+      type
+      name
+      label
+      required
+      active
+      externalId {
+        id
+        identifier { value }
+        namespace { provider tenant type }
+      }
+    }
+  }
+`;
+
+export default Route.extend(AppQueryMixin, {
+  model({ field_id: id }) {
+    const input = { id };
+    const variables = { input };
+    return this.query({ query, variables, fetchPolicy: 'network-only' }, 'textField');
+  },
+});

--- a/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-text-fields.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-text-fields.js
@@ -1,0 +1,31 @@
+import Route from '@ember/routing/route';
+import AppQueryMixin from '@identity-x/manage/mixins/app-query';
+import gql from 'graphql-tag';
+
+const query = gql`
+  query AppUsersEditCustomTextFields($input: AppUserQueryInput!) {
+    appUser(input: $input) {
+      id
+      email
+      customTextFieldAnswers {
+        id
+        field {
+          id
+          name
+          label
+          active
+        }
+        value
+      }
+    }
+  }
+`;
+
+export default Route.extend(AppQueryMixin, {
+  model() {
+    const { email } = this.modelFor('manage.orgs.view.apps.view.users.edit');
+    const input = { email };
+    const variables = { input };
+    return this.query({ query, variables, fetchPolicy: 'network-only' }, 'appUser');
+  },
+});

--- a/services/manage/app/templates/components/custom-field/card.hbs
+++ b/services/manage/app/templates/components/custom-field/card.hbs
@@ -29,5 +29,10 @@
         {{entypo-icon "edit" class="mr-1"}} Modify
       {{/link-to}}
     {{/if}}
+    {{#if (eq field.type "text")}}
+      {{#link-to "manage.orgs.view.apps.view.fields.edit.text" field.id class="btn btn-primary" role="button"}}
+        {{entypo-icon "edit" class="mr-1"}} Modify
+      {{/link-to}}
+    {{/if}}
   </div>
 </ListCard>

--- a/services/manage/app/templates/components/custom-field/modal-form.hbs
+++ b/services/manage/app/templates/components/custom-field/modal-form.hbs
@@ -116,6 +116,7 @@
               >
                 <select.option @value="select">Select</select.option>
                 <select.option @value="boolean">Boolean</select.option>
+                <select.option @value="text">Text</select.option>
               </FormElements::Select>
             </div>
           </div>

--- a/services/manage/app/templates/manage/orgs/view/apps/view/fields/edit/text.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/fields/edit/text.hbs
@@ -1,0 +1,7 @@
+<CustomField::ModalForm
+  @model={{this.model}}
+  @onSubmit={{action "update"}}
+  @title="Modify Custom Field"
+  @isActionRunning={{this.isActionRunning}}
+  @isUpdating={{true}}
+/>

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
@@ -11,20 +11,19 @@
           Address
         {{/link-to}}
       </li>
-      <li class="nav-item">
-        {{#link-to "manage.orgs.view.apps.view.users.edit.custom-select-fields" class="nav-link"}}
-          Custom Selects
-        {{/link-to}}
-      </li>
-      <li class="nav-item">
-        {{#link-to "manage.orgs.view.apps.view.users.edit.custom-boolean-fields" class="nav-link"}}
-          Custom Checkboxes
-        {{/link-to}}
-      </li>
-      <li class="nav-item">
-        {{#link-to "manage.orgs.view.apps.view.users.edit.custom-text-fields" class="nav-link"}}
-          Custom Inputs
-        {{/link-to}}
+      <li class="nav-item dropdown">
+        <a class={{customDropdownClasses}} data-toggle="dropdown" href="#" role="button" aria-expanded="false">Custom Fields</a>
+        <div class="dropdown-menu">
+          {{#link-to "manage.orgs.view.apps.view.users.edit.custom-boolean-fields" class="dropdown-item"}}
+            Checkboxes
+          {{/link-to}}
+          {{#link-to "manage.orgs.view.apps.view.users.edit.custom-text-fields" class="dropdown-item"}}
+            Text fields
+          {{/link-to}}
+          {{#link-to "manage.orgs.view.apps.view.users.edit.custom-select-fields" class="dropdown-item"}}
+            Selects
+          {{/link-to}}
+        </div>
       </li>
       <li class="nav-item">
         {{#link-to "manage.orgs.view.apps.view.users.edit.external-ids" class="nav-link"}}

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit.hbs
@@ -22,6 +22,11 @@
         {{/link-to}}
       </li>
       <li class="nav-item">
+        {{#link-to "manage.orgs.view.apps.view.users.edit.custom-text-fields" class="nav-link"}}
+          Custom Inputs
+        {{/link-to}}
+      </li>
+      <li class="nav-item">
         {{#link-to "manage.orgs.view.apps.view.users.edit.external-ids" class="nav-link"}}
           External IDs
         {{/link-to}}

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/custom-text-fields.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/custom-text-fields.hbs
@@ -1,28 +1,28 @@
 <form {{action "save" on="submit"}}>
   <fieldset disabled={{this.isActionRunning}}>
     <BsModal::Body>
-      <div class="row">
-        {{#each this.model.customTextFieldAnswers as |answer|}}
-          <div class="col-sm-6">
-            <div class="form-group">
-              <FormElements::Label>
-                <CustomField::Label @value={{answer.field.label}} />
-                <br>
-                <span class="small text-muted">({{answer.field.name}})</span>
-                {{#if (not answer.field.active)}}<span class="small text-warning">[inactive]</span>{{/if}}
-              </FormElements::Label>
-              <Input
-                @type="text"
-                @value={{answer.value}}
-                />
-            </div>
+      {{#each this.model.customTextFieldAnswers as |answer|}}
+        <div class="col-sm-6">
+          <div class="form-group">
+            <FormElements::Label>
+              <CustomField::Label @value={{answer.field.label}} />
+              <br>
+              <span class="small text-muted">({{answer.field.name}})</span>
+              {{#if (not answer.field.active)}}<span class="small text-warning">[inactive]</span>{{/if}}
+            </FormElements::Label>
+            <Input
+              @type="text"
+              @value={{answer.value}}
+              />
           </div>
-        {{else}}
+        </div>
+      {{else}}
+        <div class="col">
           <div class="row">
-            <p class="text-muted">No custom fields have been created.</p>
+            <p class="text-muted">No custom inputs have been created.</p>
           </div>
-        {{/each}}
-      </div>
+        </div>
+      {{/each}}
     </BsModal::Body>
     <BsModal::Footer>
       <FormElements::SubmitButton @class="btn btn-success" @isSaving={{this.isActionRunning}} />

--- a/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/custom-text-fields.hbs
+++ b/services/manage/app/templates/manage/orgs/view/apps/view/users/edit/custom-text-fields.hbs
@@ -1,0 +1,31 @@
+<form {{action "save" on="submit"}}>
+  <fieldset disabled={{this.isActionRunning}}>
+    <BsModal::Body>
+      <div class="row">
+        {{#each this.model.customTextFieldAnswers as |answer|}}
+          <div class="col-sm-6">
+            <div class="form-group">
+              <FormElements::Label>
+                <CustomField::Label @value={{answer.field.label}} />
+                <br>
+                <span class="small text-muted">({{answer.field.name}})</span>
+                {{#if (not answer.field.active)}}<span class="small text-warning">[inactive]</span>{{/if}}
+              </FormElements::Label>
+              <Input
+                @type="text"
+                @value={{answer.value}}
+                />
+            </div>
+          </div>
+        {{else}}
+          <div class="row">
+            <p class="text-muted">No custom fields have been created.</p>
+          </div>
+        {{/each}}
+      </div>
+    </BsModal::Body>
+    <BsModal::Footer>
+      <FormElements::SubmitButton @class="btn btn-success" @isSaving={{this.isActionRunning}} />
+    </BsModal::Footer>
+  </fieldset>
+</form>


### PR DESCRIPTION
Adds support for custom `Text`-type fields and answers. Screenshots below of UI, and example queries/mutations.

## Create field
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/1778222/165637912-de03ef2d-8b40-433c-92cd-769e7206f099.png">

```graphql

mutation CreateTextField($input: CreateTextFieldMutationInput!) {
  createTextField(input: {
    name: "usr-fav-color-00001",
    label: "What is your favorite color?",
    externalId: {
      identifier: { type: "thud", value: "qux" },
      namespace: { provider: "foo", tenant: "bar", type: "baz" },
    }
  }) {
    id
  }
}

```

## Update field
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/1778222/165636650-52c31bbb-33e6-49d9-8acc-89e8aa618454.png">

```graphql
mutation UpdateTextField($input: UpdateTextFieldMutationInput!) {
  updateTextField(input: {
    id: "62699f25c0d166015dde9703"
    name: "usr-fav-color-00001",
    label: "What is your favorite color?",
    externalId: {
      identifier: { type: "thud", value: "qux" },
      namespace: { provider: "foo", tenant: "bar", type: "baz" },
    }
  }) {
    id
  }
}
```

## Update AppUser answer
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/1778222/165636621-37670c91-086a-405c-a8f0-849fa53a7c7b.png">

```graphql
mutation UpdateAppUserCustomTextAnswers($input: UpdateAppUserCustomTextAnswersMutationInput!) {
  updateAppUserCustomTextAnswers(input: {
    id: "6215472f13ad4d5111c5854e",
    answers: [ { fieldId: "62699f25c0d166015dde9703", value: "foo-bar-baz-qux-quz" } ]
  }) {
    id
    email
    domain
    name
    customTextFieldAnswers(input: { onlyActive: true }) {
      id
      field {
        id
        name
        label
      }
      value
    }
  }
}
```