### PR TITLE
Support user impersonation

### DIFF
--- a/services/application/src/actions/user/impersonate.js
+++ b/services/application/src/actions/user/impersonate.js
@@ -7,6 +7,7 @@ const { Application, AppUser, AppUserLogin } = require('../../mongodb/models');
 module.exports = async ({
   applicationId,
   orgUserId,
+  verify,
   id,
   ip,
   ua,
@@ -38,10 +39,12 @@ module.exports = async ({
   });
 
   // Update the user with last logged in date and verified flag
-  user.set({
-    verified: true,
-    lastLoggedIn: new Date(),
-  });
+  if (verify) {
+    user.set({
+      verified: true,
+      lastLoggedIn: new Date(),
+    });
+  }
   await user.save();
 
   return { user: user.toObject(), token: { id: payload.jti, value: authToken } };

--- a/services/application/src/actions/user/impersonate.js
+++ b/services/application/src/actions/user/impersonate.js
@@ -1,0 +1,48 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+
+const { Application, AppUser, AppUserLogin } = require('../../mongodb/models');
+
+module.exports = async ({
+  applicationId,
+  orgUserId,
+  id,
+  ip,
+  ua,
+} = {}) => {
+  if (!id) throw createRequiredParamError('id');
+  if (!orgUserId) throw createRequiredParamError('orgUserId');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+
+  const app = await Application.findById(applicationId, ['id']);
+  if (!app) throw createError(404, `No application was found for '${applicationId}'`);
+
+  const user = await AppUser.findById(id, ['email']);
+  if (!user) throw createError(404, `No user was found for '${id}'`);
+
+  // Create the authenticated token.
+  const { token: authToken, payload } = await tokenService.request('create', {
+    sub: 'app-user-auth',
+    iss: applicationId,
+    payload: { aud: user.email },
+  });
+
+  // Save the login with the auth token ID (but do not await)
+  AppUserLogin.create({
+    applicationId,
+    email: user.email,
+    tokenId: payload.jti,
+    ip,
+    ua,
+  });
+
+  // Update the user with last logged in date and verified flag
+  user.set({
+    verified: true,
+    lastLoggedIn: new Date(),
+  });
+  await user.save();
+
+  return { user: user.toObject(), token: { id: payload.jti, value: authToken } };
+};

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -9,6 +9,7 @@ const { createRequiredParamError } = require('@base-cms/micro').service;
 const create = require('./create');
 const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
+const impersonate = require('./impersonate');
 const login = require('./login');
 const logout = require('./logout');
 const manageCreate = require('./manage-create');
@@ -28,6 +29,7 @@ module.exports = {
   findByEmail,
   findById: params => findById(AppUser, params),
   listForApp: params => listForApp(AppUser, params),
+  impersonate,
   login,
   logout,
   manageCreate,

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -308,6 +308,8 @@ input SetAppUserBannedMutationInput {
 input ImpersonateAppUserMutationInput {
   "The user ID to impersonate."
   id: String!
+  "If the app user account should be verified."
+  verify: Boolean = false
 }
 
 input SetAppUserExternalIdMutationInput {

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -26,6 +26,9 @@ extend type Mutation {
   setAppUserBanned(input: SetAppUserBannedMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
   setAppUserRegionalConsent(input: SetAppUserRegionalConsentMutationInput!): AppUser! @requiresAuth(type: AppUser) # can only be set by self
 
+  "Allows login of an AppUser. Requires App admin credentials."
+  impersonateAppUser(input: ImpersonateAppUserMutationInput!): AppUserAuthentication! @requiresAppRole(roles: [Owner, Administrator])
+
   updateAppUserCustomBooleanAnswers(input: UpdateAppUserCustomBooleanAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
   updateOwnAppUserCustomBooleanAnswers(input: UpdateOwnAppUserCustomBooleanAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
   updateAppUserCustomSelectAnswers(input: UpdateAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
@@ -300,6 +303,11 @@ input SetAppUserBannedMutationInput {
   id: String!
   "Whether the user will be banned or not."
   value: Boolean!
+}
+
+input ImpersonateAppUserMutationInput {
+  "The user ID to impersonate."
+  id: String!
 }
 
 input SetAppUserExternalIdMutationInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -350,12 +350,13 @@ module.exports = {
       const authorized = await user.hasOrgRole(app.getOrgId(), ['Owner', 'Administrator']);
       if (!authorized) throw new AuthenticationError('The supplied user credentials cannot be used for impersonation.');
 
-      const { id } = input;
+      const { id, verify } = input;
       const ua = req.get('user-agent');
       return applicationService.request('user.impersonate', {
         applicationId,
         orgUserId,
         id,
+        verify,
         ip: req.ip,
         ua,
       });


### PR DESCRIPTION
Allows an organization user (with `Owner` or `Administrator` role) to impersonate a user.

This allows the consuming application to use OrgUser credentials to log the user in via an external method (such as Auth0).