### PR TITLE
Allow `receiveEmail` flag to be set by mgmt user

### DIFF
--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -383,6 +383,7 @@ input UpdateAppUserPayloadInput {
   accessLevelIds: [String!] = []
   teamIds: [String!] = []
   forceProfileReVerification: Boolean = false
+  receiveEmail: Boolean
 }
 
 input UpdateAppUserMutationInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -512,6 +512,7 @@ module.exports = {
         addressExtra,
         phoneNumber,
         forceProfileReVerification,
+        receiveEmail,
       } = payload;
 
       return applicationService.request('user.updateOne', {
@@ -533,6 +534,7 @@ module.exports = {
           addressExtra,
           phoneNumber,
           forceProfileReVerification,
+          receiveEmail,
         },
       });
     },


### PR DESCRIPTION
```graphql
mutation UpdateAppUser {
  updateAppUser(input: {
    id: "6215472f13ad4d5111c5854e"
    payload: {
      email: "josh@parameter1.com"
      receiveEmail: true
    }
  }) {
    id
    email
    receiveEmail
    }
}
```
```json
{
  "data": {
    "updateAppUser": {
      "id": "6215472f13ad4d5111c5854e",
      "email": "josh@parameter1.com",
      "receiveEmail": true
    }
  }
}
```