### PR TITLE
Change email support

### DIFF
--- a/services/application/src/actions/user/change-email.js
+++ b/services/application/src/actions/user/change-email.js
@@ -1,0 +1,72 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+
+const { Application, AppUserLogin } = require('../../mongodb/models');
+const findByEmail = require('./find-by-email');
+
+module.exports = async ({
+  applicationId,
+  token,
+  ip,
+  ua,
+} = {}) => {
+  if (!token) throw createRequiredParamError('token');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+
+  const app = await Application.findById(applicationId, ['id']);
+  if (!app) throw createError(404, `No application was found for '${applicationId}'`);
+
+  const {
+    aud: email, // the new email
+    iss,
+    jti,
+    data: { email: currentEmail }, // the old email
+  } = await tokenService.request('verify', { sub: 'app-user-change-email-link', token });
+
+  if (!currentEmail) throw createError(400, 'The current email is missing from the token payload!');
+  if (!email) throw createError(400, 'No email address was provided in the token payload');
+  if (!iss) throw createError(400, 'No application ID was provided in the token payload');
+  if (iss !== applicationId) throw createError(400, 'The requested application ID does not match the token payload');
+
+  const [user, newUser] = await Promise.all([
+    findByEmail({ applicationId, email: currentEmail }),
+    findByEmail({ applicationId, email }),
+  ]);
+  if (!user) throw createError(404, `No user was found for '${currentEmail}'`);
+  if (newUser && newUser.verified) throw createError(400, `The email address ${email} cannot be used. XAVF`);
+
+  // Add the previous address to the history
+  user.emails.push(user.email);
+  // If there is an existing unverified user delete it: Unverified data is untrusted.
+  if (newUser) await newUser.delete();
+
+  // Create the authenticated token.
+  const { token: authToken, payload } = await tokenService.request('create', {
+    sub: 'app-user-auth',
+    iss: applicationId,
+    payload: { aud: email },
+  });
+
+  // Invalidate the change email link token (but do not await)
+  tokenService.request('invalidate', { jti });
+
+  // Save the login with the auth token ID (but do not await)
+  AppUserLogin.create({
+    applicationId,
+    email,
+    tokenId: payload.jti,
+    ip,
+    ua,
+  });
+
+  // Update the user with last logged in date and verified flag
+  user.set({
+    email, // Ensure the new email address is set
+    verified: true,
+    lastLoggedIn: new Date(),
+  });
+  await user.save();
+
+  return { user: user.toObject(), token: { id: payload.jti, value: authToken } };
+};

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -14,6 +14,7 @@ const login = require('./login');
 const logout = require('./logout');
 const manageCreate = require('./manage-create');
 const regionalConsentAnswer = require('./regional-constent-answer');
+const sendChangeEmailLink = require('./send-change-email-link');
 const sendLoginLink = require('./send-login-link');
 const setUnverifiedData = require('./set-unverified-data');
 const updateCustomBooleanAnswers = require('./update-custom-boolean-answers');
@@ -35,6 +36,7 @@ module.exports = {
   manageCreate,
   matchForApp: params => matchForApp(AppUser, params),
   regionalConsentAnswer,
+  sendChangeEmailLink,
   sendLoginLink,
   setUnverifiedData,
   updateField: params => updateField(AppUser, params),

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -6,6 +6,7 @@ const {
   updateFieldWithApp,
 } = require('@identity-x/utils').actions;
 const { createRequiredParamError } = require('@base-cms/micro').service;
+const changeEmail = require('./change-email');
 const create = require('./create');
 const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
@@ -25,6 +26,7 @@ const verifyAuth = require('./verify-auth');
 const AppUser = require('../../mongodb/models/app-user');
 
 module.exports = {
+  changeEmail,
   create,
   externalId,
   findByEmail,

--- a/services/application/src/actions/user/send-change-email-link.js
+++ b/services/application/src/actions/user/send-change-email-link.js
@@ -1,0 +1,122 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService, mailerService, organizationService } = require('@identity-x/service-clients');
+const { getAsObject } = require('@base-cms/object-path');
+const { stripLines } = require('@identity-x/utils');
+const { Application } = require('../../mongodb/models');
+const { SENDING_DOMAIN } = require('../../env');
+const findByEmail = require('./find-by-email');
+const { isBurnerDomain } = require('../../utils/burner-email');
+
+const createToken = ({
+  email,
+  data = {},
+  applicationId,
+  ttl = 60 * 60,
+} = {}) => tokenService.request('create', {
+  payload: { aud: email, data },
+  iss: applicationId,
+  sub: 'app-user-change-email-link',
+  ttl,
+});
+
+module.exports = async ({
+  authUrl,
+  redirectTo,
+  applicationId,
+  appContextId,
+  email,
+  newEmail,
+} = {}) => {
+  if (!authUrl) throw createRequiredParamError('authUrl');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+  if (!email) throw createRequiredParamError('email');
+  if (!newEmail) throw createRequiredParamError('newEmail');
+  if (email === newEmail) throw createError(400, 'New email must be different from current email.');
+
+  const [app, user, newUser] = await Promise.all([
+    Application.findById(applicationId, ['id', 'name', 'email', 'organizationId', 'contexts']),
+    findByEmail({ applicationId, email, fields: ['id', 'email', 'domain', 'verified'] }),
+    findByEmail({ applicationId, email: newEmail, fields: ['id', 'email', 'domain', 'verified'] }),
+  ]);
+
+  if (!app) throw createError(404, `No application was found for '${applicationId}'`);
+  if (!user) throw createError(404, `No user was found for '${email}'`);
+  if (newUser && newUser.verified) throw createError(400, `The email address ${newEmail} cannot be used. XAVF`);
+
+  // Ensure the new email domain is valid.
+  const [, domain] = newEmail.split('@');
+  if (isBurnerDomain(domain)) throw createError(422, `The email domain "${domain}" is not allowed. Please use a valid email address.`);
+
+  const org = await organizationService.request('findById', { id: app.organizationId, fields: ['company'] });
+  if (!org) throw createError(404, `No organization was found for '${app.organizationId}'`);
+  const company = getAsObject(org, 'company');
+
+  // Load the active context
+  const context = app.contexts.id(appContextId) || {};
+  const appName = context.name || app.name;
+
+  const addressFields = ['name', 'streetAddress', 'city', 'regionName', 'postalCode'];
+  const addressValues = addressFields.map(field => company[field]).filter(v => v).map(stripLines);
+  const supportEmail = context.email || app.email || company.supportEmail;
+  if (supportEmail) addressValues.push(supportEmail);
+
+  const { token } = await createToken({ applicationId, email: newEmail, data: { email } });
+  let url = `${authUrl}?token=${token}`;
+  if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;
+
+  const supportEmailHtml = supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : '';
+  const supportEmailText = supportEmail ? ` or contact our support staff at ${supportEmail}` : '';
+
+  const html = `
+    <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" id="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
+        <title>Change your email address on ${appName}</title>
+      </head>
+      <body>
+        <p>You recently requested to change your email address on <strong>${appName}</strong>. To complete this request, click on the link below. This link is good for one hour and will expire immediately after use.</p>
+        <p><a href="${url}">Change my email on ${appName}</a></p>
+        <p>If you didn't request this link, simply ignore this email${supportEmailHtml}.</p>
+        <hr>
+        <small style="font-color: #ccc;">
+          <p>Please add <em>${SENDING_DOMAIN}</em> to your address book or safe sender list to ensure you receive future emails from us.</p>
+          <p>You are receiving this email because a request to change your email address was made on ${appName}.</p>
+          <p>For additional information please contact ${appName} c/o ${addressValues.join(', ')}.</p>
+        </small>
+      </body>
+    </html>
+  `;
+
+  const text = `
+You recently requested to change your email address on ${appName}. This link is good for one hour and will expire immediately after use.
+
+Change your email on ${appName} by visiting this link:
+${url}
+
+If you didn't request this link, simply ignore this email${supportEmailText}.
+
+-------------------------
+
+Please add ${SENDING_DOMAIN} to your address book or safe sender list to ensure you receive future emails from us.
+You are receiving this email because a login request was made on ${appName}.
+For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
+  `;
+
+  await mailerService.request('send', {
+    to: user.email,
+    from: `${appName} <noreply@${SENDING_DOMAIN}>`,
+    subject: `Change your email address on ${appName}`,
+    html,
+    text,
+  });
+
+  // Unverify the existing user
+  user.verified = false;
+  await user.save();
+
+  return 'ok';
+};

--- a/services/application/src/actions/user/send-change-email-link.js
+++ b/services/application/src/actions/user/send-change-email-link.js
@@ -107,7 +107,7 @@ For additional information please contact ${appName} c/o ${addressValues.join(',
   `;
 
   await mailerService.request('send', {
-    to: user.email,
+    to: newEmail,
     from: `${appName} <noreply@${SENDING_DOMAIN}>`,
     subject: `Change your email address on ${appName}`,
     html,

--- a/services/application/src/mongodb/schema/app-user.js
+++ b/services/application/src/mongodb/schema/app-user.js
@@ -81,6 +81,11 @@ const schema = new Schema({
     set: normalizeEmail,
     validate: emailValidator,
   },
+  emails: {
+    type: [String],
+    trim: true,
+    lowercase: true,
+  },
   domain: {
     type: String,
     required: true,

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -40,7 +40,7 @@ extend type Mutation {
   addAppUserExternalId(input: SetAppUserExternalIdMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
 
   "Sends a change email verification link to the user's new email address."
-  sendAppUserChangeEmailLink(input: SendAppUserChangeEmailLinkMutationInput!): String @requiresAuth(type: AppUser)
+  sendOwnAppUserChangeEmailLink(input: SendOwnAppUserChangeEmailLinkMutationInput!): String @requiresAuth(type: AppUser)
 }
 
 enum AppUserSortField {
@@ -290,7 +290,7 @@ input ManageCreateAppUserMutationInput {
   teamIds: [String!] = []
 }
 
-input SendAppUserChangeEmailLinkMutationInput {
+input SendOwnAppUserChangeEmailLinkMutationInput {
   email: String!
   source: String
   authUrl: String!

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -38,6 +38,9 @@ extend type Mutation {
   setAppUserUnverifiedData(input: SetAppUserUnverifiedDataMutationInput!): AppUser! @requiresApp # must be public
   "Adds an external identifier (with namespace) to an app user."
   addAppUserExternalId(input: SetAppUserExternalIdMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
+
+  "Sends a change email verification link to the user's new email address."
+  sendAppUserChangeEmailLink(input: SendAppUserChangeEmailLinkMutationInput!): String @requiresAuth(type: AppUser)
 }
 
 enum AppUserSortField {
@@ -285,6 +288,15 @@ input ManageCreateAppUserMutationInput {
   phoneNumber: String
   accessLevelIds: [String!] = []
   teamIds: [String!] = []
+}
+
+input SendAppUserChangeEmailLinkMutationInput {
+  email: String!
+  source: String
+  authUrl: String!
+  redirectTo: String
+  "If provided, will use the matched application context when sending the notification email."
+  appContextId: String
 }
 
 input SendAppUserLoginLinkMutationInput {

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -41,6 +41,8 @@ extend type Mutation {
 
   "Sends a change email verification link to the user's new email address."
   sendOwnAppUserChangeEmailLink(input: SendOwnAppUserChangeEmailLinkMutationInput!): String @requiresAuth(type: AppUser)
+  "Verifies and logs in the app user using their new email address."
+  changeAppUserEmail(input: ChangeAppUserEmailMutationInput!): AppUserAuthentication! @requiresApp # must be public
 }
 
 enum AppUserSortField {
@@ -235,6 +237,10 @@ input MatchAppUsersQueryInput {
 input AppUserSortInput {
   field: AppUserSortField = id
   order: SortOrder = desc
+}
+
+input ChangeAppUserEmailMutationInput {
+  token: String!
 }
 
 input CheckContentAccessQueryInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -236,6 +236,21 @@ module.exports = {
     /**
      *
      */
+    changeAppUserEmail: (_, { input }, { req, app }) => {
+      const applicationId = app.getId();
+      const { token } = input;
+      const ua = req.get('user-agent');
+      return applicationService.request('user.changeEmail', {
+        applicationId,
+        token,
+        ip: req.ip,
+        ua,
+      });
+    },
+
+    /**
+     *
+     */
     createAppUser: (_, { input }, { app }) => {
       const applicationId = app.getId();
       const {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -405,7 +405,7 @@ module.exports = {
     /**
      *
      */
-    sendAppUserChangeEmailLink: (_, { input }, { app, user }) => {
+    sendOwnAppUserChangeEmailLink: (_, { input }, { app, user }) => {
       const applicationId = app.getId();
       const {
         email,

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -405,6 +405,29 @@ module.exports = {
     /**
      *
      */
+    sendAppUserChangeEmailLink: (_, { input }, { app, user }) => {
+      const applicationId = app.getId();
+      const {
+        email,
+        source,
+        authUrl,
+        redirectTo,
+        appContextId,
+      } = input;
+      return applicationService.request('user.sendChangeEmailLink', {
+        applicationId,
+        appContextId,
+        authUrl,
+        redirectTo,
+        source,
+        newEmail: email,
+        email: user.user.email,
+      });
+    },
+
+    /**
+     *
+     */
     sendAppUserLoginLink: (_, { input }, { app }) => {
       const applicationId = app.getId();
       const {


### PR DESCRIPTION
Adds facility for an AppUser to change their email address. This is only permissible under the following conditions:
- The user is logged in (login token has not expired)
- There is no `verified` app user with the requested new email address
- The new email address passes validation (burner address, etc)
- The user clicks the link sent to the new address to confirm access.

1. AppUser initiates an email change request. If successful, a change email link token will be sent to the new address. The AppUser is marked as verified=false.
```graphql
mutation {
  sendOwnAppUserChangeEmailLink(input: {
    email: "josh+123@parameter1.com", # The new email address
    authUrl: "http://www-p1-sandbox.dev.parameter1.com:51269/user/changeEmail"
  })
}
```
2. Upon clicking the link, the handler at the authUrl makes the request to change their email (and receives a new login token)
```graphql
mutation {
  changeAppUserEmail(input: {
  token: "eyJhbGciOiJIUzI1N..." # The change email link token
}) {
    user {
      id
      email # The new email address
    }
    token {
      id
      value
    }
  }
}
```