### PR TITLE
Add support for an app user identity token

### DIFF
--- a/services/application/src/actions/user/create-identity-token.js
+++ b/services/application/src/actions/user/create-identity-token.js
@@ -1,0 +1,30 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+const { Application, AppUser } = require('../../mongodb/models');
+
+module.exports = async ({
+  applicationId,
+  id,
+} = {}) => {
+  if (!applicationId) throw createRequiredParamError('applicationId');
+  if (!id) throw createRequiredParamError('id');
+
+  const [app, user] = await Promise.all([
+    Application.findById(applicationId, ['id', 'name', 'email', 'organizationId', 'contexts']),
+    AppUser.findOne({ applicationId, _id: id }),
+  ]);
+
+  if (!app) throw createError(404, `No application was found for '${applicationId}'`);
+  if (!user) throw createError(404, `No user was found for '${id}'`);
+
+  // Load the active context
+  const { token } = await tokenService.request('create', {
+    payload: { aud: user.id },
+    iss: applicationId,
+    sub: 'app-user-identity',
+    ttl: 2 * 365 * 24 * 60 * 60,
+  });
+
+  return token;
+};

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -8,6 +8,7 @@ const {
 const { createRequiredParamError } = require('@base-cms/micro').service;
 const changeEmail = require('./change-email');
 const create = require('./create');
+const createIdentityToken = require('./create-identity-token');
 const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
 const impersonate = require('./impersonate');
@@ -22,12 +23,14 @@ const updateCustomBooleanAnswers = require('./update-custom-boolean-answers');
 const updateCustomSelectAnswers = require('./update-custom-select-answers');
 const updateOne = require('./update-one');
 const verifyAuth = require('./verify-auth');
+const verifyIdentityToken = require('./verify-identity-token');
 
 const AppUser = require('../../mongodb/models/app-user');
 
 module.exports = {
   changeEmail,
   create,
+  createIdentityToken,
   externalId,
   findByEmail,
   findById: params => findById(AppUser, params),
@@ -47,6 +50,7 @@ module.exports = {
   updateCustomSelectAnswers,
   updateOne,
   verifyAuth,
+  verifyIdentityToken,
   setLastSeen: async ({ id }) => {
     if (!id) throw createRequiredParamError('id');
     const doc = await AppUser.findById(id);

--- a/services/application/src/actions/user/verify-identity-token.js
+++ b/services/application/src/actions/user/verify-identity-token.js
@@ -1,0 +1,25 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { tokenService } = require('@identity-x/service-clients');
+const { AppUser } = require('../../mongodb/models');
+
+module.exports = async ({ token } = {}) => {
+  if (!token) throw createRequiredParamError('token');
+  try {
+    const verified = await tokenService.request('verify', { sub: 'app-user-identity', token });
+    console.log(verified);
+
+    const { aud: id, iss: applicationId } = verified;
+    if (!id) throw createError(400, 'No user id was provided in the token payload');
+    if (!applicationId) throw createError(400, 'No application id was provided in the token payload');
+
+    const user = await AppUser.findOne({ applicationId, _id: id });
+
+    if (!user) throw createError(404, `No user was found for '${id}'`);
+    if (user.id !== id) throw createError(401, 'The user id does not match the token id.');
+
+    return { user, token: verified };
+  } catch (e) {
+    throw createError(401, e.message);
+  }
+};

--- a/services/graphql/src/graphql/context/user.js
+++ b/services/graphql/src/graphql/context/user.js
@@ -3,12 +3,13 @@ const { get } = require('object-path');
 const { membershipService, userService, applicationService } = require('@identity-x/service-clients');
 
 const { isArray } = Array;
-const allowedTypes = ['OrgUser', 'AppUser', 'OrgUserApiToken'];
+const allowedTypes = ['OrgUser', 'AppUser', 'OrgUserApiToken', 'AppIdentity'];
 
 class UserContext {
   constructor(authorization) {
     this.authorization = authorization;
     this.user = {};
+    this.identity = {};
     this.decoded = {};
   }
 
@@ -25,6 +26,8 @@ class UserContext {
           await this.loadForOrg(token);
         } else if (type === 'OrgUserApiToken') {
           await this.loadForOrgApiToken(token);
+        } else if (type === 'AppIdentity') {
+          await this.loadForAppIdentity(token);
         } else {
           await this.loadForApp(token);
         }
@@ -44,6 +47,12 @@ class UserContext {
     const { token: decoded, user } = await userService.request('verifyAuth', { token });
     this.decoded = decoded;
     this.user = user;
+  }
+
+  async loadForAppIdentity(token) {
+    const { token: decoded, user } = await applicationService.request('user.verifyIdentityToken', { token });
+    this.decoded = decoded;
+    this.identity = user;
   }
 
   async loadForApp(token) {


### PR DESCRIPTION
Allows an `OrgUser` to create an Identity token for a specified AppUser. A consuming application can find an IdentityX AppUser that they have externally identified, and obtain an Identity token. The Identity token is valid for 2 years, and provides access to an extremely narrow view of the AppUser's data:
- The AppUser `id` (for tracking purposes)
- All available external IDs (for the same)
- If the user must explicitly verify their data
- If all required fields (required custom boolean, select, and optional core/root fields via input) have been provided.

In a consuming application, the `AppIdentity` bearer prefix can be used to indicate that the supplied token should be verified as an identity token, rather than a user token, and to show the correct context.

When using an identity token, the `activeAppContext` query field will contain the additional identity-specific fields:
```graphql
# With `authorization: AppIdentity eyJhbGciOiJI...` header
query ActiveContext {
  activeAppContext {
    application {
      id
      name
      organization { id name }
    }
    user {
      id
      email
    }
    identity {
      id
      mustReVerifyProfile
      hasAllFields(fields: ["countryCode"])
      externalIds { id }
    }
  }
}
```
```json
{
  "data": {
    "activeAppContext": {
      "application": {
        "id": "5d1b86070ce467bff670a052",
        "name": "Cogs & Widgets",
        "organization": {
          "id": "5d1b820d5e7209436c7de987",
          "name": "Contoso"
        }
      },
      "user": null,
      "identity": {
        "id": "6215472f13ad4d5111c5854e",
        "mustReVerifyProfile": false,
        "hasAllFields": true,
        "externalIds": [
          {
            "id": "omeda.allucd.customer*4902E1408978D9Y~encrypted"
          },
          {
            "id": "omeda.hcl.customer*1034764015"
          }
        ]
      }
    }
  }
}
```