### PR TITLE
Add operation to find an app user by id

### DIFF
--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -5,6 +5,7 @@ module.exports = gql`
 extend type Query {
   appUsers(input: AppUsersQueryInput!): AppUserConnection! @requiresAppRole
   appUser(input: AppUserQueryInput = {}): AppUser @requiresApp # must be public
+  appUserById(input: AppUserByIdQueryInput!): AppUser @requiresAppRole
   activeAppUser: AppUser @requiresAuth(type: AppUser)
   activeAppContext: AppContext! @requiresApp # must be public
   checkContentAccess(input: CheckContentAccessQueryInput!): AppContentAccess! @requiresApp # must be public
@@ -218,6 +219,10 @@ input AppUserCustomSelectFieldAnswersInput {
 
 input AppUserQueryInput {
   email: String!
+}
+
+input AppUserByIdQueryInput {
+  id: String!
 }
 
 input AppUsersQueryInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -180,6 +180,20 @@ module.exports = {
     },
 
     /**
+     *
+     */
+    appUserById: (_, { input }, { app }, info) => {
+      const { id } = input;
+      const applicationId = app.getId();
+      const fields = typeProjection(info);
+      return applicationService.request('user.findById', {
+        applicationId,
+        id,
+        fields,
+      });
+    },
+
+    /**
      * @todo This should be secured, otherwise anyone could guess by email
      */
     appUser: (_, { input }, { app }, info) => {


### PR DESCRIPTION
```graphql
# With `authorization: OrgUser eyJhbGciOiJIUzI1NiI...` header
query {
  appUserById(input: { id: "6215472f13ad4d5111c5854e" }) {
    id
    email
    organization
    customSelectFieldAnswers(input: { onlyActive: true }) {
      id
      field {
        required
      }
      hasAnswered
    }
  }
}
```
```json
{
  "data": {
    "appUserById": {
      "id": "6215472f13ad4d5111c5854e",
      "email": "josh@parameter1.com",
      "organization": "Parameter1, LLC",
      "customSelectFieldAnswers": [
        {
          "id": "626fe8854e597205b368a50f",
          "field": {
            "required": true
          },
          "hasAnswered": true
        }
      ]
    }
  }
}
```