### PR TITLE
Store and retrieve custom attributes on AppUsers

### DIFF
--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -18,6 +18,7 @@ const regionalConsentAnswer = require('./regional-constent-answer');
 const sendChangeEmailLink = require('./send-change-email-link');
 const sendLoginLink = require('./send-login-link');
 const setUnverifiedData = require('./set-unverified-data');
+const updateCustomAttributes = require('./update-custom-attributes');
 const updateCustomBooleanAnswers = require('./update-custom-boolean-answers');
 const updateCustomSelectAnswers = require('./update-custom-select-answers');
 const updateOne = require('./update-one');
@@ -43,6 +44,7 @@ module.exports = {
   setUnverifiedData,
   updateField: params => updateField(AppUser, params),
   updateFieldWithApp: params => updateFieldWithApp(AppUser, params),
+  updateCustomAttributes,
   updateCustomBooleanAnswers,
   updateCustomSelectAnswers,
   updateOne,

--- a/services/application/src/actions/user/update-custom-attributes.js
+++ b/services/application/src/actions/user/update-custom-attributes.js
@@ -16,10 +16,15 @@ module.exports = async ({
   if (!user) throw createError(404, `No user was found for '${id}'`);
 
   Object.keys(attributes).forEach((k) => {
-    console.log('ca.', k, attributes[k]);
-    user.set(`customAttributes.${k}`, attributes[k]);
+    let v = attributes[k];
+    if (typeof v === 'string') {
+      // Trim strings
+      v = `${v}`.trim();
+      // Unset if sent an empty value
+      if (v === '') v = null;
+    }
+    user.set(`customAttributes.${k}`, v === null ? undefined : v);
   });
-  console.log(attributes, user.customAttributes);
 
   try {
     await user.save();

--- a/services/application/src/actions/user/update-custom-attributes.js
+++ b/services/application/src/actions/user/update-custom-attributes.js
@@ -1,0 +1,30 @@
+const { createError } = require('micro');
+const { createRequiredParamError } = require('@base-cms/micro').service;
+const { handleError } = require('@identity-x/utils').mongoose;
+
+const { AppUser } = require('../../mongodb/models');
+
+module.exports = async ({
+  id,
+  applicationId,
+  attributes,
+} = {}) => {
+  if (!id) throw createRequiredParamError('id');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+
+  const user = await AppUser.findByIdForApp(id, applicationId);
+  if (!user) throw createError(404, `No user was found for '${id}'`);
+
+  Object.keys(attributes).forEach((k) => {
+    console.log('ca.', k, attributes[k]);
+    user.set(`customAttributes.${k}`, attributes[k]);
+  });
+  console.log(attributes, user.customAttributes);
+
+  try {
+    await user.save();
+    return user;
+  } catch (e) {
+    throw handleError(createError, e);
+  }
+};

--- a/services/application/src/mongodb/schema/app-user.js
+++ b/services/application/src/mongodb/schema/app-user.js
@@ -176,6 +176,10 @@ const schema = new Schema({
     type: [customSelectFieldAnswerSchema],
     default: () => [],
   },
+  customAttributes: {
+    type: Object,
+    default: () => ({}),
+  },
 }, { timestamps: true });
 
 schema.plugin(applicationPlugin, { collateWhen: ['email'] });

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -108,7 +108,7 @@ type AppUser {
   "Shows all answers to custom select questions. By default this will include all questions, even if the user has not answered."
   customSelectFieldAnswers(input: AppUserCustomSelectFieldAnswersInput = {}): [AppUserCustomSelectFieldAnswer!]! @projection
   "Shows all custom attributes stored on the user."
-  customAttributes: JSON! @projection
+  customAttributes: JSONObject! @projection
   "Lists all external IDs + namespaces associated with this user."
   externalIds: [AppUserExternalEntityId!]! @projection
   createdAt: Date @projection
@@ -422,14 +422,14 @@ input UpdateAppUserCustomAttributesMutationInput {
   "The user id to update."
   id: String!
   "The attributes to modify."
-  attributes: JSON! = {}
+  attributes: JSONObject! = {}
 }
 
 input UpdateOwnAppUserCustomAttributesMutationInput {
   "The user id to update."
   id: String!
   "The attributes to modify."
-  attributes: JSON! = {}
+  attributes: JSONObject! = {}
 }
 
 input UpdateAppUserCustomBooleanAnswersMutationInput {

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -30,6 +30,8 @@ extend type Mutation {
   "Allows login of an AppUser. Requires App admin credentials."
   impersonateAppUser(input: ImpersonateAppUserMutationInput!): AppUserAuthentication! @requiresAppRole(roles: [Owner, Administrator])
 
+  updateAppUserCustomAttributes(input: UpdateAppUserCustomAttributesMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
+  updateOwnAppUserCustomAttributes(input: UpdateOwnAppUserCustomAttributesMutationInput!): AppUser! @requiresAuth(type: AppUser)
   updateAppUserCustomBooleanAnswers(input: UpdateAppUserCustomBooleanAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
   updateOwnAppUserCustomBooleanAnswers(input: UpdateOwnAppUserCustomBooleanAnswersMutationInput!): AppUser! @requiresAuth(type: AppUser)
   updateAppUserCustomSelectAnswers(input: UpdateAppUserCustomSelectAnswersMutationInput!): AppUser! @requiresAppRole(roles: [Owner, Administrator, Member])
@@ -105,6 +107,8 @@ type AppUser {
   customBooleanFieldAnswers(input: AppUserCustomBooleanFieldAnswersInput = {}): [AppUserCustomBooleanFieldAnswer!]! @projection
   "Shows all answers to custom select questions. By default this will include all questions, even if the user has not answered."
   customSelectFieldAnswers(input: AppUserCustomSelectFieldAnswersInput = {}): [AppUserCustomSelectFieldAnswer!]! @projection
+  "Shows all custom attributes stored on the user."
+  customAttributes: JSON! @projection
   "Lists all external IDs + namespaces associated with this user."
   externalIds: [AppUserExternalEntityId!]! @projection
   createdAt: Date @projection
@@ -412,6 +416,20 @@ input UpdateAppUserPayloadInput {
 input UpdateAppUserMutationInput {
   id: String!
   payload: UpdateAppUserPayloadInput!
+}
+
+input UpdateAppUserCustomAttributesMutationInput {
+  "The user id to update."
+  id: String!
+  "The attributes to modify."
+  attributes: JSON! = {}
+}
+
+input UpdateOwnAppUserCustomAttributesMutationInput {
+  "The user id to update."
+  id: String!
+  "The attributes to modify."
+  attributes: JSON! = {}
 }
 
 input UpdateAppUserCustomBooleanAnswersMutationInput {

--- a/services/graphql/src/graphql/definitions/index.js
+++ b/services/graphql/src/graphql/definitions/index.js
@@ -15,6 +15,7 @@ module.exports = gql`
 scalar Date
 scalar ObjectID
 scalar JSON
+scalar JSONObject
 
 directive @projectUsing(type: String!) on OBJECT
 directive @projection(localField: String, needs: [String] = []) on FIELD_DEFINITION

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -43,6 +43,8 @@ module.exports = {
       return regionalConsentAnswers.filter(answer => policyIds.includes(answer._id));
     },
 
+    customAttributes: ({ customAttributes }) => customAttributes || {},
+
     customBooleanFieldAnswers: async ({ customBooleanFieldAnswers }, { input }, { app }) => {
       const {
         fieldIds,
@@ -588,6 +590,33 @@ module.exports = {
           forceProfileReVerification,
           receiveEmail,
         },
+      });
+    },
+
+    /**
+     *
+     */
+    updateAppUserCustomAttributes: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const { id, attributes } = input;
+      return applicationService.request('user.updateCustomAttributes', {
+        id,
+        applicationId,
+        attributes,
+      });
+    },
+
+    /**
+     *
+     */
+    updateOwnAppUserCustomAttributes: (_, { input }, { user }) => {
+      const id = user.getId();
+      const applicationId = user.getAppId();
+      const { attributes } = input;
+      return applicationService.request('user.updateCustomAttributes', {
+        id,
+        applicationId,
+        attributes,
       });
     },
 

--- a/services/graphql/src/graphql/resolvers/index.js
+++ b/services/graphql/src/graphql/resolvers/index.js
@@ -1,4 +1,4 @@
-const GraphQLJSON = require('graphql-type-json');
+const { GraphQLJSON, GraphQLJSONObject } = require('graphql-type-json');
 const deepAssign = require('deep-assign');
 
 const accessLevel = require('./access-level');
@@ -31,6 +31,7 @@ module.exports = deepAssign(
     Date: DateType,
     ObjectID: ObjectIDType,
     JSON: GraphQLJSON,
+    JSONObject: GraphQLJSONObject,
 
     /**
      * Root queries.


### PR DESCRIPTION
Adds generic `customAttributes` field to `AppUser` model and allows it to be modified via new `set[Own]AppUserCustomAttributes` mutations.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1778222/213538175-e5aaca0c-cb05-455e-8af6-26d7c0eedb8a.png">
<img width="848" alt="image" src="https://user-images.githubusercontent.com/1778222/213538350-b11c3e00-a0db-4580-ad78-c2ae91112463.png">
<img width="841" alt="image" src="https://user-images.githubusercontent.com/1778222/213538267-48694620-ce74-4990-bab7-89cdc2de3b6a.png">

