### PR TITLE
Remove default value from JSONObject type input fields

### DIFF
--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -422,14 +422,14 @@ input UpdateAppUserCustomAttributesMutationInput {
   "The user id to update."
   id: String!
   "The attributes to modify."
-  attributes: JSONObject! = {}
+  attributes: JSONObject!
 }
 
 input UpdateOwnAppUserCustomAttributesMutationInput {
   "The user id to update."
   id: String!
   "The attributes to modify."
-  attributes: JSONObject! = {}
+  attributes: JSONObject!
 }
 
 input UpdateAppUserCustomBooleanAnswersMutationInput {


### PR DESCRIPTION
Prevents hard 500 error when attempting to parse the schema definitions introduced in #27 