### PR TITLE
Fix export download links

### DIFF
--- a/services/export/src/actions/user/export-for-app.js
+++ b/services/export/src/actions/user/export-for-app.js
@@ -5,8 +5,7 @@ const { getAsArray } = require('@base-cms/object-path');
 const { AsyncParser } = require('json2csv');
 const newrelic = require('../../newrelic');
 const { sendFailure, sendSuccess, streamResults } = require('../../utils');
-const { upload } = require('../../s3');
-const { AWS_S3_BUCKET_NAME } = require('../../env');
+const { upload, sign } = require('../../s3');
 
 const { createRequiredParamError } = service;
 
@@ -83,8 +82,7 @@ module.exports = async ({
 
     const filename = `app-user-export-${applicationId}-${Date.now()}.csv`;
     await upload({ filename, contents });
-
-    const url = `https://${AWS_S3_BUCKET_NAME}.s3.amazonaws.com/${filename}`;
+    const url = await sign({ filename });
     await sendSuccess({ email, url });
     return 'ok';
   } catch (e) {

--- a/services/export/src/s3.js
+++ b/services/export/src/s3.js
@@ -13,6 +13,11 @@ const client = new AWS.S3({
 
 module.exports = {
   client,
+  sign: async ({ filename }) => client.getSignedUrlPromise('getObject', {
+    Bucket: AWS_S3_BUCKET_NAME,
+    Key: filename,
+    Expires: 60 * 60 * 24 * 7, // Maximum duration is 1 week
+  }),
   upload: ({ filename, contents }) => new Promise((resolve, reject) => client.putObject({
     ACL: 'public-read',
     Body: contents,

--- a/services/export/src/s3.js
+++ b/services/export/src/s3.js
@@ -23,8 +23,7 @@ module.exports = {
     Body: contents,
     Bucket: AWS_S3_BUCKET_NAME,
     ContentDisposition: `attachment; filename="${filename}"`,
-    ContentType: 'text/plain; charset=utf8',
-    Expires: Math.floor(Date.now().valueOf() / 1000) * 60 * 60 * 24 * 30,
+    ContentType: 'text/csv; charset=utf8',
     Key: filename,
   }, (err, data) => {
     if (err) {

--- a/services/export/src/s3.js
+++ b/services/export/src/s3.js
@@ -19,7 +19,6 @@ module.exports = {
     Expires: 60 * 60 * 24 * 7, // Maximum duration is 1 week
   }),
   upload: ({ filename, contents }) => new Promise((resolve, reject) => client.putObject({
-    ACL: 'public-read',
     Body: contents,
     Bucket: AWS_S3_BUCKET_NAME,
     ContentDisposition: `attachment; filename="${filename}"`,

--- a/services/export/src/utils/send-sucess.js
+++ b/services/export/src/utils/send-sucess.js
@@ -13,7 +13,7 @@ const html = url => `
   <body>
     <h1>Your export is available.</h1>
     <p>You recently requested an export of IdentityX data. Your report can be accessed by visiting the following URL.</p>
-    <p><a href="${url}">Download report</a></p>
+    <p><a clicktracking=off href="${url}">Download report</a></p>
     <p>If you didn't request this export, simply ignore this email or <a href="mailto:${SUPPORT_EMAIL}">contact our support staff</a>.</p>
     <hr>
     <small style="font-color: #ccc;">


### PR DESCRIPTION
- Removes public read ACL from links, now returns a signed URL to access them.
- Removes invalid `Expires` header from the object
- Fixes content type header
- Removes URL tracking (prevented download due to redirect)