### PR TITLE
Ensure users are not returned from other apps

### DIFF
--- a/packages/utils/src/actions/find-by-id-for-app.js
+++ b/packages/utils/src/actions/find-by-id-for-app.js
@@ -1,0 +1,8 @@
+const { createRequiredParamError } = require('@base-cms/micro').service;
+
+module.exports = async (Model, { id, applicationId, fields }) => {
+  if (!id) throw createRequiredParamError('id');
+  if (!applicationId) throw createRequiredParamError('applicationId');
+  const doc = await Model.findByIdForApp(id, applicationId, fields);
+  return doc || null;
+};

--- a/packages/utils/src/actions/index.js
+++ b/packages/utils/src/actions/index.js
@@ -1,5 +1,6 @@
 const find = require('./find');
 const findById = require('./find-by-id');
+const findByIdForApp = require('./find-by-id-for-app');
 const listForApp = require('./list-for-app');
 const listForOrg = require('./list-for-org');
 const matchForApp = require('./match-for-app');
@@ -11,6 +12,7 @@ const updateMany = require('./update-many');
 module.exports = {
   find,
   findById,
+  findByIdForApp,
   listForApp,
   listForOrg,
   matchForApp,

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -2,7 +2,7 @@ const {
   updateField,
   listForApp,
   matchForApp,
-  findById,
+  findByIdForApp,
   updateFieldWithApp,
 } = require('@identity-x/utils').actions;
 const { createRequiredParamError } = require('@base-cms/micro').service;
@@ -31,7 +31,7 @@ module.exports = {
   create,
   externalId,
   findByEmail,
-  findById: params => findById(AppUser, params),
+  findById: params => findByIdForApp(AppUser, params),
   listForApp: params => listForApp(AppUser, params),
   impersonate,
   login,


### PR DESCRIPTION
Currently if you request a valid user ID with the incorrect application ID, the app user will be returned, making user data accessible to contexts outside of the intended application.