### PR TITLE
Fix margins and default language value

### DIFF
--- a/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
@@ -22,7 +22,12 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
     async create(closeModal) {
       try {
         this.startAction();
-        const { name, description, email, language } = this.get('model');
+        const {
+          name,
+          description,
+          email,
+          language = 'en-us',
+        } = this.get('model');
         const input = { name, description, email, language };
         const variables = { input };
         const refetchQueries = ['Org', 'OrgApps'];

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
@@ -30,7 +30,7 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           name,
           description,
           email,
-          language
+          language = 'en-us',
         } = this.get('model');
         const payload = { name, description, email, language };
         const variables = { applicationId: this.application.id, payload };

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -16,7 +16,7 @@
 </div>
 <div class="row">
   <div class="col">
-    <div class="form-group mb-0">
+    <div class="form-group">
       <FormElements::Label @for="app.description">Description</FormElements::Label>
       <Textarea @id="app.description" @class="form-control" @value={{model.description}} @rows={{3}} />
     </div>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -16,7 +16,7 @@
 </div>
 <div class="row">
   <div class="col">
-    <div class="form-group mb-0">
+    <div class="form-group">
       <FormElements::Label @for="app.description">Description</FormElements::Label>
       <Textarea @id="app.description" @class="form-control" @value={{model.description}} @rows={{3}} />
     </div>


### PR DESCRIPTION
Addresses errors introduced in #29 when creating applications or contexts: 
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/1778222/234621715-f9071c58-ce9e-4ec7-aef2-2e39ea6137ac.png">

Adds default value to create payloads to fulfill GraphQL validation requirements and fixes margin/alignment issue with language field.