### PR TITLE
Globally delete application users for an organization

### DIFF
--- a/services/application/src/actions/user/delete-for-org.js
+++ b/services/application/src/actions/user/delete-for-org.js
@@ -1,0 +1,136 @@
+const { Types } = require('mongoose');
+const { tokenService } = require('@identity-x/service-clients');
+const { service } = require('@base-cms/micro');
+const models = require('../../mongodb/models');
+
+const { Application } = models;
+
+const { ObjectId } = Types;
+
+const { createRequiredParamError } = service;
+
+module.exports = async ({
+  organizationId,
+  email,
+} = {}) => {
+  if (!organizationId) throw createRequiredParamError('organizationId');
+  if (!email) throw createRequiredParamError('email');
+
+  const pipeline = [
+    { $match: { organizationId: new ObjectId(organizationId) } },
+    { $group: { _id: null, appIds: { $push: '$_id' } } },
+    {
+      $lookup: {
+        from: 'app-users',
+        let: { appIds: '$appIds' },
+        as: 'appUser',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  // enter target user email here
+                  { $eq: ['$email', email.toLowerCase()] },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { email: 1 } },
+        ],
+      },
+    },
+    { $unwind: '$appUser' },
+    {
+      $lookup: {
+        from: 'comments',
+        let: { appIds: '$appIds', appUserId: '$appUser._id' },
+        as: 'comments',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  // enter target user email here
+                  { $eq: ['$appUserId', '$$appUserId'] },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { _id: 1 } },
+        ],
+      },
+    },
+    {
+      $lookup: {
+        from: 'app-user-logins',
+        let: { appIds: '$appIds', email: '$appUser.email' },
+        as: 'appUserLogins',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: ['$email', '$$email'] },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { _id: 1 } },
+        ],
+      },
+    },
+    {
+      $lookup: {
+        from: 'tokens',
+        let: { email: '$appUser.email' },
+        as: 'tokens',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  // enter target user email here
+                  { $eq: ['$payload.aud', '$$email'] },
+                ],
+              },
+            },
+          },
+          { $project: { _id: 1, iss: 1 } },
+        ],
+      },
+    },
+  ];
+
+  const results = await Application.aggregate(pipeline);
+  const [doc] = results;
+
+  if (!doc) return false;
+  const stringifiedAppIds = new Set(doc.appIds.map(id => `${id}`));
+  const result = {
+    ...doc,
+    tokens: doc.tokens.filter(token => stringifiedAppIds.has(token.iss)),
+  };
+
+  const criterion = [
+    ['AppUser', { applicationId: { $in: result.appIds }, email: result.appUser.email }],
+    ['AppUserLogin', { _id: { $in: result.appUserLogins.map(login => login._id) } }],
+    ['Comment', { _id: { $in: result.comments.map(comment => comment._id) } }],
+  ];
+
+  await Promise.all([
+    Promise.all(criterion.map(async ([modelName, criteria]) => {
+      const Model = models[modelName];
+      await Model.deleteMany(criteria);
+    })),
+    (async () => {
+      const jtis = result.tokens.map(token => token._id);
+      if (!jtis.length) return;
+      await Promise.all(jtis.map(jti => tokenService.request('invalidate', { jti })));
+    })(),
+  ]);
+
+  return true;
+};

--- a/services/application/src/actions/user/delete-for-org.js
+++ b/services/application/src/actions/user/delete-for-org.js
@@ -29,7 +29,6 @@ module.exports = async ({
             $match: {
               $expr: {
                 $and: [
-                  // enter target user email here
                   { $eq: ['$email', email.toLowerCase()] },
                   { $in: ['$applicationId', '$$appIds'] },
                 ],
@@ -51,7 +50,6 @@ module.exports = async ({
             $match: {
               $expr: {
                 $and: [
-                  // enter target user email here
                   { $eq: ['$appUserId', '$$appUserId'] },
                   { $in: ['$applicationId', '$$appIds'] },
                 ],
@@ -88,16 +86,7 @@ module.exports = async ({
         let: { email: '$appUser.email' },
         as: 'tokens',
         pipeline: [
-          {
-            $match: {
-              $expr: {
-                $and: [
-                  // enter target user email here
-                  { $eq: ['$payload.aud', '$$email'] },
-                ],
-              },
-            },
-          },
+          { $match: { $expr: { $eq: ['$payload.aud', '$$email'] } } },
           { $project: { _id: 1, iss: 1 } },
         ],
       },

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -9,6 +9,7 @@ const {
 const { createRequiredParamError } = require('@base-cms/micro').service;
 const changeEmail = require('./change-email');
 const create = require('./create');
+const deleteForOrg = require('./delete-for-org');
 const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
 const impersonate = require('./impersonate');
@@ -30,6 +31,7 @@ const AppUser = require('../../mongodb/models/app-user');
 module.exports = {
   changeEmail,
   create,
+  deleteForOrg,
   externalId,
   findByEmail,
   findById: params => findById(AppUser, params),

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -46,6 +46,8 @@ extend type Mutation {
   sendOwnAppUserChangeEmailLink(input: SendOwnAppUserChangeEmailLinkMutationInput!): String @requiresAuth(type: AppUser)
   "Verifies and logs in the app user using their new email address."
   changeAppUserEmail(input: ChangeAppUserEmailMutationInput!): AppUserAuthentication! @requiresApp # must be public
+
+  deleteAppUserForCurrentOrg(input: DeleteAppUserForCurrentOrgInput!): Boolean! @requiresOrgRole(roles: [Owner, Administrator])
 }
 
 enum AppUserSortField {
@@ -270,6 +272,10 @@ input CreateAppUserMutationInput {
   street: String
   addressExtra: String
   phoneNumber: String
+}
+
+input DeleteAppUserForCurrentOrgInput {
+  email: String!
 }
 
 input ForceProfileReVerificationAppUserMutationInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -303,6 +303,15 @@ module.exports = {
       });
     },
 
+    deleteAppUserForCurrentOrg: (_, { input }, { org }) => {
+      const organizationId = org.getId();
+      const { email } = input;
+      return applicationService.request('user.deleteForOrg', {
+        organizationId,
+        email,
+      });
+    },
+
     /**
      *
      */

--- a/services/manage/app/components/organization/delete-user-from-org.js
+++ b/services/manage/app/components/organization/delete-user-from-org.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import ActionMixin from '@identity-x/manage/mixins/action-mixin';
+import OrgQueryMixin from '@identity-x/manage/mixins/org-query';
+import { inject } from '@ember/service';
+import gql from 'graphql-tag';
+
+const mutation = gql`
+  mutation DeleteUserFromOrg($input: DeleteAppUserForCurrentOrgInput!) {
+    deleteAppUserForCurrentOrg(input: $input)
+  }
+`;
+
+export default Component.extend(ActionMixin, OrgQueryMixin, {
+  email: null,
+  errorNotifier: inject(),
+  result: null,
+  resultEmail: null,
+
+  actions: {
+    async delete() {
+      this.set('result', null);
+      this.startAction();
+      try {
+        const input = { email: this.email };
+        const result = await this.mutate({ mutation, variables: { input } }, 'deleteAppUserForCurrentOrg');
+        this.set('resultEmail', this.email);
+        this.set('email', null);
+        this.set('result', result);
+      } catch(e) {
+        this.errorNotifier.show(e);
+      } finally {
+        this.endAction();
+      }
+    }
+  },
+});

--- a/services/manage/app/templates/components/organization/delete-user-from-org.hbs
+++ b/services/manage/app/templates/components/organization/delete-user-from-org.hbs
@@ -1,0 +1,38 @@
+<form class="card" {{action "delete" on="submit"}}>
+  <div class="card-header">
+    <EntypoIcon @name="remove-user" /> Delete User From All Applications
+  </div>
+  <div class="card-body">
+    <div class="form-group">
+      <FormElements::Label @for="app-user.email">Email Address</FormElements::Label>
+      <Input
+        @id="app-user.email"
+        @type="email"
+        @class="form-control"
+        @value={{this.email}}
+        @required={{true}}
+      />
+    </div>
+
+    {{#if (eq this.result true)}}
+      <div class="alert-info mt-3 mb-0 alert" role="alert">
+        The user {{ this.resultEmail }} was successfully deleted for all applications.
+      </div>
+    {{/if}}
+    {{#if (eq this.result false)}}
+      <div class="alert-warning mt-3 mb-0 alert" role="alert">
+        The user {{ this.resultEmail }} was not found.
+      </div>
+    {{/if}}
+  </div>
+  <div class="card-footer">
+    <FormElements::SubmitButton
+      @class="btn btn-danger"
+      @label="Delete"
+      @onSavingLabel="Deleting..."
+      @icon="circle-with-cross"
+      @disabled={{this.isActionRunning}}
+      @isSaving={{this.isActionRunning}}
+    />
+  </div>
+</form>

--- a/services/manage/app/templates/manage/orgs/view/settings.hbs
+++ b/services/manage/app/templates/manage/orgs/view/settings.hbs
@@ -103,7 +103,9 @@
       </div>
     </form>
 
-    <Organization::RegionalConsentPolicies @policies={{this.model.regionalConsentPolicies}} />
+    <Organization::RegionalConsentPolicies @class="mb-3" @policies={{this.model.regionalConsentPolicies}} />
+
+    <Organization::DeleteUserFromOrg />
   </div>
 </div>
 


### PR DESCRIPTION
Finds all application users for the current org context and the provided email address and deletes them and all associated relationships. This action is only available for organization users with Owner or Administrator roles and can be found on the Organization > Settings page.

<img width="1785" alt="image" src="https://github.com/parameter1/identity-x/assets/3289485/ecc7f4fe-a67d-45bf-a0a1-6d77415386af">
