### PR TITLE
Add login link template override for unverified & verified verbiage 

### DIFF
--- a/services/application/package.json
+++ b/services/application/package.json
@@ -26,6 +26,7 @@
     "mongoose": "^5.5.11",
     "newrelic": "^6.14.0",
     "object-path": "^0.11.4",
+    "striptags": "^3.2.0",
     "validator": "^11.0.0"
   },
   "devDependencies": {

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -49,7 +49,7 @@ module.exports = async ({
   const company = getAsObject(org, 'company');
 
   // Load the active context & ensure fallback object has toObject function like mongoose object
-  const context = app.contexts.id(appContextId) || { toObject: () => ({}) };
+  const context = app.contexts.id(appContextId) || {};
   const appName = context.name || app.name;
 
   const addressFields = ['name', 'streetAddress', 'city', 'regionName', 'postalCode'];
@@ -63,10 +63,13 @@ module.exports = async ({
   let url = `${authUrl}?token=${token}`;
   if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;
 
-  const loginLinkTemplate = {
-    ...app.loginLinkTemplate.toObject(),
-    ...context.loginLinkTemplate.toObject(),
-  };
+  const loginLinkTemplate = ['subject', 'unverifiedVerbiage', 'verifiedVerbiage'].reduce((o, key) => {
+    const contextValue = context.loginLinkTemplate ? context.loginLinkTemplate[key] : null;
+    return {
+      ...o,
+      [key]: contextValue || app.loginLinkTemplate[key],
+    };
+  }, {});
 
   const { subject, html, text } = templates[language] ? templates[language]({
     sendingDomain,

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -63,18 +63,9 @@ module.exports = async ({
   let url = `${authUrl}?token=${token}`;
   if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;
 
-  const appTemp = app.loginLinkTemplate || {};
-  const contextTemp = context.loginLinkTemplate || {};
   const loginLinkTemplate = {
-    ...((contextTemp.subjectLine || appTemp.subjectLine)
-      && { subjectLine: contextTemp.subjectLine || appTemp.subjectLine }
-    ),
-    ...((contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage)
-      && { unverifiedVerbiage: contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage }
-    ),
-    ...((contextTemp.verifiedVerbiage || appTemp.verifiedVerbiage)
-      && { verifiedVerbiage: contextTemp.verifiedVerbiage || appTemp.verifiedVerbiage }
-    ),
+    ...app.loginLinkTemplate.toObject(),
+    ...context.loginLinkTemplate.toObject(),
   };
 
   const { subject, html, text } = templates[language] ? templates[language]({

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -1,7 +1,7 @@
 const { createError } = require('micro');
 const { createRequiredParamError } = require('@base-cms/micro').service;
 const { tokenService, mailerService, organizationService } = require('@identity-x/service-clients');
-const { get, getAsObject } = require('@base-cms/object-path');
+const { getAsObject } = require('@base-cms/object-path');
 const { stripLines } = require('@identity-x/utils');
 const { Application } = require('../../mongodb/models');
 const { SENDING_DOMAIN: sendingDomain } = require('../../env');
@@ -65,13 +65,16 @@ module.exports = async ({
 
   const appTemp = app.loginLinkTemplate || {};
   const contextTemp = context.loginLinkTemplate || {};
-  const subjectLine = contextTemp.subjectLine || appTemp.subjectLine;
-  const unverifiedVerbiage = contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage;
-  const verifiedVerbiage = contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage;
   const loginLinkTemplate = {
-    ...(subjectLine && { subjectLine }),
-    ...(unverifiedVerbiage && { unverifiedVerbiage }),
-    ...(verifiedVerbiage && { verifiedVerbiage }),
+    ...((contextTemp.subjectLine || appTemp.subjectLine)
+      && { subjectLine: contextTemp.subjectLine || appTemp.subjectLine }
+    ),
+    ...((contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage)
+      && { unverifiedVerbiage: contextTemp.unverifiedVerbiage || appTemp.unverifiedVerbiage }
+    ),
+    ...((contextTemp.verifiedVerbiage || appTemp.verifiedVerbiage)
+      && { verifiedVerbiage: contextTemp.verifiedVerbiage || appTemp.verifiedVerbiage }
+    ),
   };
 
   const { subject, html, text } = templates[language] ? templates[language]({

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -48,8 +48,8 @@ module.exports = async ({
   if (!org) throw createError(404, `No organization was found for '${app.organizationId}'`);
   const company = getAsObject(org, 'company');
 
-  // Load the active context
-  const context = app.contexts.id(appContextId) || {};
+  // Load the active context & ensure fallback object has toObject function like mongoose object
+  const context = app.contexts.id(appContextId) || { toObject: () => ({}) };
   const appName = context.name || app.name;
 
   const addressFields = ['name', 'streetAddress', 'city', 'regionName', 'postalCode'];

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -10,7 +10,7 @@ module.exports = ({
   user,
 } = {}) => {
   const { verified } = user;
-  const subject = loginLinkTemplate.subjectLine ? loginLinkTemplate.subjectLine : 'Your personal login link';
+  const subject = loginLinkTemplate.subject ? loginLinkTemplate.subject : 'Your personal login link';
   const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage ? loginLinkTemplate.unverifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage ? loginLinkTemplate.verifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
@@ -51,6 +51,6 @@ module.exports = ({
   You are receiving this email because a login request was made on ${appName}.
   For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
     `,
-    subject: stripTags(subject, []),
+    subject,
   });
 };

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -1,45 +1,56 @@
+const stripTags = require('striptags');
+
 module.exports = ({
   sendingDomain,
   supportEmail,
   url,
   appName,
   addressValues,
-} = {}) => ({
-  html: `
-  <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-  <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-      <meta name="viewport" id="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
-      <title>Your personal login link</title>
-    </head>
-    <body>
-      <p>You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour and will expire immediately after use.</p>
-      <p><a href="${url}">Login to ${appName}</a></p>
-      <p>If you didn't request this link, simply ignore this email${supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : ''}.</p>
-      <hr>
-      <small style="font-color: #ccc;">
-        <p>Please add <em>${sendingDomain}</em> to your address book or safe sender list to ensure you receive future emails from us.</p>
-        <p>You are receiving this email because a login request was made on ${appName}.</p>
-        <p>For additional information please contact ${appName} c/o ${addressValues.join(', ')}.</p>
-      </small>
-    </body>
-  </html>
-  `,
-  text: `
-You recently requested to log in to ${appName}. This link is good for one hour and will expire immediately after use.
+  loginLinkTemplate,
+  user,
+} = {}) => {
+  const { verified } = user;
+  const subject = loginLinkTemplate.subjectLine ? loginLinkTemplate.subjectLine : 'Your personal login link';
+  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage ? loginLinkTemplate.unverifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
+  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage ? loginLinkTemplate.verifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
+  const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
+  return ({
+    html: `
+    <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" id="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
+        <title>Your personal login link</title>
+      </head>
+      <body>
+        <p>${verbiage}</p>
+        <p><a href="${url}">Login to ${appName}</a></p>
+        <p>If you didn't request this link, simply ignore this email${supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : ''}.</p>
+        <hr>
+        <small style="font-color: #ccc;">
+          <p>Please add <em>${sendingDomain}</em> to your address book or safe sender list to ensure you receive future emails from us.</p>
+          <p>You are receiving this email because a login request was made on ${appName}.</p>
+          <p>For additional information please contact ${appName} c/o ${addressValues.join(', ')}.</p>
+        </small>
+      </body>
+    </html>
+    `,
+    text: `
+  ${stripTags(verbiage, [])}
 
-Login to ${appName} by visiting this link:
-${url}
+  Login to ${appName} by visiting this link:
+  ${url}
 
-If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.
+  If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.
 
--------------------------
+  -------------------------
 
-Please add ${sendingDomain} to your address book or safe sender list to ensure you receive future emails from us.
-You are receiving this email because a login request was made on ${appName}.
-For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
-  `,
-  subject: 'Your personal login link',
-});
+  Please add ${sendingDomain} to your address book or safe sender list to ensure you receive future emails from us.
+  You are receiving this email because a login request was made on ${appName}.
+  For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
+    `,
+    subject: stripTags(subject, []),
+  });
+};

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -26,7 +26,7 @@ module.exports = ({
       </head>
       <body>
         <p>${verbiage}</p>
-        <p><a href="${url}">Login to ${appName}</a></p>
+        <p><a href="${url}">Log in to ${appName}</a></p>
         <p>If you didn't request this link, simply ignore this email${supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : ''}.</p>
         <hr>
         <small style="font-color: #ccc;">
@@ -40,7 +40,7 @@ module.exports = ({
     text: `
 ${stripTags(verbiage, [])}
 
-Login to ${appName} by visiting this link:
+Log in to ${appName} by visiting this link:
 ${url}
 
 If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -10,9 +10,9 @@ module.exports = ({
   user,
 } = {}) => {
   const { verified } = user;
-  const subject = loginLinkTemplate.subject ? loginLinkTemplate.subject : 'Your personal login link';
-  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage ? loginLinkTemplate.unverifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
-  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage ? loginLinkTemplate.verifiedVerbiage : `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
+  const subject = loginLinkTemplate.subject || 'Your personal login link';
+  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
+  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
   return ({
     html: `
@@ -38,18 +38,18 @@ module.exports = ({
     </html>
     `,
     text: `
-  ${stripTags(verbiage, [])}
+${stripTags(verbiage, [])}
 
-  Login to ${appName} by visiting this link:
-  ${url}
+Login to ${appName} by visiting this link:
+${url}
 
-  If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.
+If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.
 
-  -------------------------
+-------------------------
 
-  Please add ${sendingDomain} to your address book or safe sender list to ensure you receive future emails from us.
-  You are receiving this email because a login request was made on ${appName}.
-  For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
+Please add ${sendingDomain} to your address book or safe sender list to ensure you receive future emails from us.
+You are receiving this email because a login request was made on ${appName}.
+For additional information please contact ${appName} c/o ${addressValues.join(', ')}.
     `,
     subject,
   });

--- a/services/application/src/email-templates/login-link/es-mx.js
+++ b/services/application/src/email-templates/login-link/es-mx.js
@@ -1,34 +1,44 @@
+const stripTags = require('striptags');
+
 module.exports = ({
   sendingDomain,
   supportEmail,
   url,
   appName,
   addressValues,
-} = {}) => ({
-  html: `
-  <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
-  <html lang="es">
-    <head>
-      <meta charset="UTF-8">
-      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-      <meta name="viewport" id="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
-      <title>Su enlace de inicio de sesión personal</title>
-    </head>
-    <body>
-      <p>Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.</p>
-      <p><a href="${url}">Iniciar sesión en ${appName}</a></p>
-      <p>Si no solicitó este enlace, simplemente ignore este correo electrónico${supportEmail ? ` o <a href="mailto:${supportEmail}">comuníquese con nuestro personal de soporte</a>` : ''}.</p>
-      <hr>
-      <small style="font-color: #ccc;">
-        <p>Agregue <em>${sendingDomain}</em> a su libreta de direcciones o lista de remitentes seguros para asegurarse de recibir nuestros correos electrónicos en el futuro</p>
-        <p>Está recibiendo este correo electrónico porque se realizó una solicitud de inicio de sesión en ${appName}.</p>
-        <p>Para obtener información adicional, comuníquese con ${appName} ${addressValues.join(', ')}.</p>
-      </small>
-    </body>
-  </html>
-`,
-  text: `
-Recientemente solicitó iniciar sesión en ${appName}. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.
+  loginLinkTemplate,
+  user,
+} = {}) => {
+  const { verified } = user;
+  const subject = loginLinkTemplate.subject ? loginLinkTemplate.subject : 'Su enlace de inicio de sesión personal';
+  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage ? loginLinkTemplate.unverifiedVerbiage : `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
+  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage ? loginLinkTemplate.verifiedVerbiage : `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
+  const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
+  return ({
+    html: `
+    <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+    <html lang="es">
+      <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" id="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
+        <title>Su enlace de inicio de sesión personal</title>
+      </head>
+      <body>
+        <p>${verbiage}</p>
+        <p><a href="${url}">Iniciar sesión en ${appName}</a></p>
+        <p>Si no solicitó este enlace, simplemente ignore este correo electrónico${supportEmail ? ` o <a href="mailto:${supportEmail}">comuníquese con nuestro personal de soporte</a>` : ''}.</p>
+        <hr>
+        <small style="font-color: #ccc;">
+          <p>Agregue <em>${sendingDomain}</em> a su libreta de direcciones o lista de remitentes seguros para asegurarse de recibir nuestros correos electrónicos en el futuro</p>
+          <p>Está recibiendo este correo electrónico porque se realizó una solicitud de inicio de sesión en ${appName}.</p>
+          <p>Para obtener información adicional, comuníquese con ${appName} ${addressValues.join(', ')}.</p>
+        </small>
+      </body>
+    </html>
+  `,
+    text: `
+${stripTags(verbiage)}
 
 Iniciar sesión en ${appName}:
 ${url}
@@ -40,6 +50,7 @@ Si no solicitó este enlace, simplemente ignore este correo electrónico${suppor
 Agregue ${sendingDomain} a su libreta de direcciones o lista de remitentes seguros para asegurarse de recibir nuestros correos electrónicos en el futuro
 Usted esta recibiendo este correo porque una solicitud fue hecha a ${appName}.
 Para obtener información adicional, comuníquese con ${appName} ${addressValues.join(', ')}.
-`,
-  subject: 'Su enlace de inicio de sesión personal',
-});
+  `,
+    subject,
+  });
+};

--- a/services/application/src/email-templates/login-link/es-mx.js
+++ b/services/application/src/email-templates/login-link/es-mx.js
@@ -10,9 +10,9 @@ module.exports = ({
   user,
 } = {}) => {
   const { verified } = user;
-  const subject = loginLinkTemplate.subject ? loginLinkTemplate.subject : 'Su enlace de inicio de sesión personal';
-  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage ? loginLinkTemplate.unverifiedVerbiage : `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
-  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage ? loginLinkTemplate.verifiedVerbiage : `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
+  const subject = loginLinkTemplate.subject || 'Su enlace de inicio de sesión personal';
+  const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
+  const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
   return ({
     html: `

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -12,14 +12,17 @@ const stripHtml = (v) => {
 const loginLinkTemplate = new Schema({
   subject: {
     type: String,
+    trim: true,
     set: stripHtml,
   },
   unverifiedVerbiage: {
     type: String,
+    trim: true,
     set: stripHtml,
   },
   verifiedVerbiage: {
     type: String,
+    trim: true,
     set: stripHtml,
   },
 });

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -12,24 +12,15 @@ const stripHtml = (v) => {
 const loginLinkTemplate = new Schema({
   subject: {
     type: String,
-    set: (v) => {
-      if (!v) return null;
-      return stripHtml(v);
-    },
+    set: stripHtml,
   },
   unverifiedVerbiage: {
     type: String,
-    set: (v) => {
-      if (!v) return null;
-      return stripHtml(v);
-    },
+    set: stripHtml,
   },
   verifiedVerbiage: {
     type: String,
-    set: (v) => {
-      if (!v) return null;
-      return stripHtml(v);
-    },
+    set: stripHtml,
   },
 });
 

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -50,7 +50,7 @@ const contextSchema = new Schema({
     type: String,
     trim: true,
   },
-  loginLinkTemplate: { type: loginLinkTemplate },
+  loginLinkTemplate: { type: loginLinkTemplate, get: v => (v || {}) },
   language: {
     type: String,
     default: 'en-us',
@@ -75,7 +75,7 @@ const schema = new Schema({
     type: String,
     trim: true,
   },
-  loginLinkTemplate: { type: loginLinkTemplate },
+  loginLinkTemplate: { type: loginLinkTemplate, get: v => (v || {}) },
   language: {
     type: String,
     default: 'en-us',

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -10,7 +10,7 @@ const stripHtml = (v) => {
 };
 
 const loginLinkTemplate = new Schema({
-  subjectLine: {
+  subject: {
     type: String,
     set: (v) => {
       if (!v) return null;

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -1,7 +1,37 @@
 const { Schema } = require('mongoose');
+const stripTags = require('striptags');
 const { organizationPlugin } = require('@identity-x/mongoose-plugins');
 const { normalizeEmail } = require('@identity-x/utils');
 const { emailValidator } = require('@identity-x/mongoose-plugins');
+
+const stripHtml = (v) => {
+  if (!v) return null;
+  return stripTags(v, ['em', 'i', 'b']);
+};
+
+const loginLinkTemplate = new Schema({
+  subjectLine: {
+    type: String,
+    set: (v) => {
+      if (!v) return null;
+      return stripHtml(v);
+    },
+  },
+  unverifiedVerbiage: {
+    type: String,
+    set: (v) => {
+      if (!v) return null;
+      return stripHtml(v);
+    },
+  },
+  verifiedVerbiage: {
+    type: String,
+    set: (v) => {
+      if (!v) return null;
+      return stripHtml(v);
+    },
+  },
+});
 
 const contextSchema = new Schema({
   name: {
@@ -20,6 +50,7 @@ const contextSchema = new Schema({
     type: String,
     trim: true,
   },
+  loginLinkTemplate: { type: loginLinkTemplate },
   language: {
     type: String,
     default: 'en-us',
@@ -44,6 +75,7 @@ const schema = new Schema({
     type: String,
     trim: true,
   },
+  loginLinkTemplate: { type: loginLinkTemplate },
   language: {
     type: String,
     default: 'en-us',

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -6,7 +6,7 @@ const { emailValidator } = require('@identity-x/mongoose-plugins');
 
 const stripHtml = (v) => {
   if (!v) return null;
-  return stripTags(v, ['em', 'i', 'b']);
+  return stripTags(v, ['b', 'strong', 'em', 'i', 'u']);
 };
 
 const loginLinkTemplate = new Schema({

--- a/services/graphql/src/graphql/definitions/application.js
+++ b/services/graphql/src/graphql/definitions/application.js
@@ -29,6 +29,7 @@ type Application {
   name: String! @projection
   email: String @projection
   description: String @projection
+  loginLinkTemplate: LoginLinkTemplate @projection
   language: String! @projection
   organization: Organization! @projection(localField: "organizationId")
   contexts: [ApplicationContext!]! @projection
@@ -39,7 +40,20 @@ type ApplicationContext {
   name: String!
   email: String
   description: String
+  loginLinkTemplate: LoginLinkTemplate
   language: String!
+}
+
+type LoginLinkTemplate {
+  subjectLine: String
+  unverifiedVerbiage: String
+  verifiedVerbiage: String
+}
+
+input LoginLinkTemplatePayloadInput {
+  subjectLine: String
+  unverifiedVerbiage: String
+  verifiedVerbiage: String
 }
 
 input AddApplicationContextMutationInput {
@@ -52,6 +66,7 @@ input ApplicationContextPayloadInput {
   name: String!
   email: String!
   description: String
+  loginLinkTemplate: LoginLinkTemplatePayloadInput
   language: String!
 }
 
@@ -63,6 +78,7 @@ input CreateApplicationMutationInput {
   name: String!
   email: String!
   description: String
+  loginLinkTemplate: LoginLinkTemplatePayloadInput
   language: String!
 }
 
@@ -90,6 +106,7 @@ input UpdateApplicationPayloadInput {
   name: String!
   email: String!
   description: String
+  loginLinkTemplate: LoginLinkTemplatePayloadInput
   language: String!
 }
 

--- a/services/graphql/src/graphql/definitions/application.js
+++ b/services/graphql/src/graphql/definitions/application.js
@@ -45,13 +45,13 @@ type ApplicationContext {
 }
 
 type LoginLinkTemplate {
-  subjectLine: String
+  subject: String
   unverifiedVerbiage: String
   verifiedVerbiage: String
 }
 
 input LoginLinkTemplatePayloadInput {
-  subjectLine: String
+  subject: String
   unverifiedVerbiage: String
   verifiedVerbiage: String
 }

--- a/services/graphql/src/graphql/resolvers/application.js
+++ b/services/graphql/src/graphql/resolvers/application.js
@@ -42,8 +42,18 @@ module.exports = {
      *
      */
     createApplication: (_, { input }, { org }) => {
-      const { name, description, email } = input;
-      const payload = { name, description, email };
+      const {
+        name,
+        description,
+        loginLinkTemplate,
+        email,
+      } = input;
+      const payload = {
+        name,
+        description,
+        loginLinkTemplate,
+        email,
+      };
       const organizationId = org.getId();
       return applicationService.request('create', {
         organizationId,

--- a/services/manage/app/components/application/context/fields.js
+++ b/services/manage/app/components/application/context/fields.js
@@ -4,6 +4,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     if (!this.model) this.set('model', {});
+    if (!this.model.loginLinkTemplate) this.set('model.loginLinkTemplate', {});
   },
 
   actions: {

--- a/services/manage/app/components/application/modal-form/general-fields.js
+++ b/services/manage/app/components/application/modal-form/general-fields.js
@@ -4,6 +4,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     if (!this.model) this.set('model', {});
+    if (!this.model.loginLinkTemplate) this.set('model.loginLinkTemplate', {});
   },
 
   actions: {

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
@@ -37,7 +37,7 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
         const input = {
           name,
           description,
-          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          loginLinkTemplate: this.formatLoginLinkTemplateInput(loginLinkTemplate),
           email,
           language,
         };

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
@@ -10,6 +10,11 @@ const mutation = gql`
       id
       name
       description
+      loginLinkTemplate {
+        subjectLine
+        unverifiedVerbiage
+        verifiedVerbiage
+      }
       language
     }
   }
@@ -25,10 +30,17 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
         const {
           name,
           description,
+          loginLinkTemplate,
           email,
           language = 'en-us',
         } = this.get('model');
-        const input = { name, description, email, language };
+        const input = {
+          name,
+          description,
+          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          email,
+          language,
+        };
         const variables = { input };
         const refetchQueries = ['Org', 'OrgApps'];
         await this.mutate({ mutation, variables, refetchQueries }, 'createApplication');

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
@@ -11,7 +11,7 @@ const mutation = gql`
       name
       description
       loginLinkTemplate {
-        subjectLine
+        subject
         unverifiedVerbiage
         verifiedVerbiage
       }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
@@ -10,6 +10,11 @@ const mutation = gql`
       id
       name
       email
+      loginLinkTemplate {
+        subjectLine
+        unverifiedVerbiage
+        verifiedVerbiage
+      }
       description
       language
     }
@@ -27,10 +32,17 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           id,
           name,
           description,
+          loginLinkTemplate,
           email,
           language,
         } = this.get('model');
-        const payload = { name, description, email, language };
+        const payload = {
+          name,
+          description,
+          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          email,
+          language,
+        };
         const input = { id, payload };
         const variables = { input };
         const refetchQueries = ['OrgApps'];

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
@@ -39,7 +39,7 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
         const payload = {
           name,
           description,
-          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          loginLinkTemplate: this.formatLoginLinkTemplateInput(loginLinkTemplate),
           email,
           language,
         };

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
@@ -11,7 +11,7 @@ const mutation = gql`
       name
       email
       loginLinkTemplate {
-        subjectLine
+        subject
         unverifiedVerbiage
         verifiedVerbiage
       }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
@@ -41,7 +41,7 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
         const payload = {
           name,
           description,
-          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          loginLinkTemplate: this.formatLoginLinkTemplateInput(loginLinkTemplate),
           email,
           language,
         };

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
@@ -14,7 +14,7 @@ const mutation = gql`
         email
         description
         loginLinkTemplate {
-          subjectLine
+          subject
           unverifiedVerbiage
           verifiedVerbiage
         }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
@@ -13,6 +13,11 @@ const mutation = gql`
         name
         email
         description
+        loginLinkTemplate {
+          subjectLine
+          unverifiedVerbiage
+          verifiedVerbiage
+        }
         language
       }
     }
@@ -30,9 +35,16 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           name,
           description,
           email,
+          loginLinkTemplate,
           language = 'en-us',
         } = this.get('model');
-        const payload = { name, description, email, language };
+        const payload = {
+          name,
+          description,
+          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          email,
+          language,
+        };
         const variables = { applicationId: this.application.id, payload };
         await this.mutate({ mutation, variables }, 'addApplicationContext');
         await this.transitionToRoute('manage.orgs.view.apps.list.edit.contexts.index');

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
@@ -13,6 +13,11 @@ const mutation = gql`
         name
         email
         description
+        loginLinkTemplate {
+          subjectLine
+          unverifiedVerbiage
+          verifiedVerbiage
+        }
         language
       }
     }
@@ -30,10 +35,17 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           id,
           name,
           description,
+          loginLinkTemplate,
           email,
           language
         } = this.get('model');
-        const payload = { name, description, email, language };
+        const payload = {
+          name,
+          description,
+          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          email,
+          language,
+        };
         const variables = { applicationId: this.application.id, contextId: id, payload };
         await this.mutate({ mutation, variables }, 'updateApplicationContext');
         await this.transitionToRoute('manage.orgs.view.apps.list.edit.contexts.index');

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
@@ -14,7 +14,7 @@ const mutation = gql`
         email
         description
         loginLinkTemplate {
-          subjectLine
+          subject
           unverifiedVerbiage
           verifiedVerbiage
         }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
@@ -42,7 +42,7 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
         const payload = {
           name,
           description,
-          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          loginLinkTemplate: this.formatLoginLinkTemplateInput(loginLinkTemplate),
           email,
           language,
         };

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
@@ -12,7 +12,7 @@ const mutation = gql`
       email
       description
       loginLinkTemplate {
-        subjectLine
+        subject
         unverifiedVerbiage
         verifiedVerbiage
       }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
@@ -11,6 +11,11 @@ const mutation = gql`
       name
       email
       description
+      loginLinkTemplate {
+        subjectLine
+        unverifiedVerbiage
+        verifiedVerbiage
+      }
       language
     }
   }
@@ -27,10 +32,17 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           id,
           name,
           description,
+          loginLinkTemplate = {},
           email,
           language
         } = this.get('model');
-        const payload = { name, description, email, language };
+        const payload = {
+          name,
+          description,
+          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          email,
+          language,
+        };
         const input = { id, payload };
         const variables = { input };
         await this.mutate({ mutation, variables }, 'updateApplication');

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
@@ -32,14 +32,14 @@ export default Controller.extend(ActionMixin, OrgQueryMixin, {
           id,
           name,
           description,
-          loginLinkTemplate = {},
+          loginLinkTemplate,
           email,
           language
         } = this.get('model');
         const payload = {
           name,
           description,
-          loginLinkTemplate: this.validateLoginLinkTemplateObj(loginLinkTemplate),
+          loginLinkTemplate: this.formatLoginLinkTemplateInput(loginLinkTemplate),
           email,
           language,
         };

--- a/services/manage/app/mixins/action-mixin.js
+++ b/services/manage/app/mixins/action-mixin.js
@@ -26,6 +26,14 @@ export default Mixin.create(LoadingMixin, {
     this.hideLoading();
   },
 
+  validateLoginLinkTemplateObj(loginLinkTemplate = {}){
+    return {
+      ...(loginLinkTemplate.subjectLine && { subjectLine: loginLinkTemplate.subjectLine }),
+      ...(loginLinkTemplate.unverifiedVerbiage && { unverifiedVerbiage: loginLinkTemplate.unverifiedVerbiage }),
+      ...(loginLinkTemplate.verifiedVerbiage && { verifiedVerbiage: loginLinkTemplate.verifiedVerbiage }),
+    };
+  },
+
   sendEventAction(name, ...args) {
     const fn = this.get(name);
     if (typeof fn === 'function') return fn(...args);

--- a/services/manage/app/mixins/action-mixin.js
+++ b/services/manage/app/mixins/action-mixin.js
@@ -28,7 +28,7 @@ export default Mixin.create(LoadingMixin, {
 
   validateLoginLinkTemplateObj(loginLinkTemplate = {}){
     return {
-      ...(loginLinkTemplate.subjectLine && { subjectLine: loginLinkTemplate.subjectLine }),
+      ...(loginLinkTemplate.subject && { subject: loginLinkTemplate.subject }),
       ...(loginLinkTemplate.unverifiedVerbiage && { unverifiedVerbiage: loginLinkTemplate.unverifiedVerbiage }),
       ...(loginLinkTemplate.verifiedVerbiage && { verifiedVerbiage: loginLinkTemplate.verifiedVerbiage }),
     };

--- a/services/manage/app/mixins/action-mixin.js
+++ b/services/manage/app/mixins/action-mixin.js
@@ -26,11 +26,11 @@ export default Mixin.create(LoadingMixin, {
     this.hideLoading();
   },
 
-  validateLoginLinkTemplateObj(loginLinkTemplate = {}){
+  formatLoginLinkTemplateInput({ subject, unverifiedVerbiage, verifiedVerbiage } = {}){
     return {
-      ...(loginLinkTemplate.subject && { subject: loginLinkTemplate.subject }),
-      ...(loginLinkTemplate.unverifiedVerbiage && { unverifiedVerbiage: loginLinkTemplate.unverifiedVerbiage }),
-      ...(loginLinkTemplate.verifiedVerbiage && { verifiedVerbiage: loginLinkTemplate.verifiedVerbiage }),
+      subject,
+      unverifiedVerbiage,
+      verifiedVerbiage,
     };
   },
 

--- a/services/manage/app/routes/manage/orgs/view/apps.js
+++ b/services/manage/app/routes/manage/orgs/view/apps.js
@@ -8,6 +8,11 @@ const query = gql`
       id
       name
       description
+      loginLinkTemplate {
+        subjectLine
+        unverifiedVerbiage
+        verifiedVerbiage
+      }
     }
   }
 `;

--- a/services/manage/app/routes/manage/orgs/view/apps.js
+++ b/services/manage/app/routes/manage/orgs/view/apps.js
@@ -9,7 +9,7 @@ const query = gql`
       name
       description
       loginLinkTemplate {
-        subjectLine
+        subject
         unverifiedVerbiage
         verifiedVerbiage
       }

--- a/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
@@ -25,6 +25,7 @@ const query = gql`
           unverifiedVerbiage
           verifiedVerbiage
         }
+        language
       }
     }
   }

--- a/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
@@ -10,7 +10,7 @@ const query = gql`
       email
       description
       loginLinkTemplate {
-        subjectLine
+        subject
         unverifiedVerbiage
         verifiedVerbiage
       }
@@ -21,7 +21,7 @@ const query = gql`
         email
         description
         loginLinkTemplate {
-          subjectLine
+          subject
           unverifiedVerbiage
           verifiedVerbiage
         }

--- a/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
@@ -9,12 +9,22 @@ const query = gql`
       name
       email
       description
+      loginLinkTemplate {
+        subjectLine
+        unverifiedVerbiage
+        verifiedVerbiage
+      }
       language
       contexts {
         id
         name
         email
         description
+        loginLinkTemplate {
+          subjectLine
+          unverifiedVerbiage
+          verifiedVerbiage
+        }
       }
     }
   }

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -24,6 +24,30 @@
 </div>
 <div class="row">
   <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.subjectLine">Subject Line test</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.subjectLine" @class="form-control" @value={{model.loginLinkTemplate.subjectLine}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Unverified Verbiage</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.unverifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.unverifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Verified Verbiage</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
     <div class="form-group mb-0">
       <FormElements::Label @for="app.language">Language</FormElements::Label>
       <FormElements::Select @id="app.language" @required={{true}} @value={{model.language}} @on-change={{action "setLanguage"}} @class="custom-select" as |select|>

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -25,8 +25,8 @@
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.subjectLine">Subject Line test</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.subjectLine" @class="form-control" @value={{model.loginLinkTemplate.subjectLine}} @rows={{3}} />
+      <FormElements::Label @for="app.loginLinkTemplate.subject">Subject Line test</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} @rows={{3}} />
     </div>
   </div>
 </div>

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -22,18 +22,18 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row d-none">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.subject">Subject Line test</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} @rows={{3}} />
+      <FormElements::Label @for="app.loginLinkTemplate.subject">Login Email Subject</FormElements::Label>
+      <Input @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} />
     </div>
   </div>
 </div>
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Unverified Verbiage</FormElements::Label>
+      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Login Email Unverified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.unverifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.unverifiedVerbiage}} @rows={{3}} />
     </div>
   </div>
@@ -41,7 +41,7 @@
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Verified Verbiage</FormElements::Label>
+      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Login Email Verified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
     </div>
   </div>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -24,6 +24,30 @@
 </div>
 <div class="row">
   <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.subjectLine">Subject Line test</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.subjectLine" @class="form-control" @value={{model.loginLinkTemplate.subjectLine}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Unverified Verbiage</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.unverifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.unverifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Verified Verbiage</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
     <div class="form-group mb-0">
       <FormElements::Label @for="app.language">Language</FormElements::Label>
       <FormElements::Select @id="app.language" @required={{true}} @value={{model.language}} @on-change={{action "setLanguage"}} @class="custom-select" as |select|>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -25,8 +25,8 @@
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.subjectLine">Subject Line test</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.subjectLine" @class="form-control" @value={{model.loginLinkTemplate.subjectLine}} @rows={{3}} />
+      <FormElements::Label @for="app.loginLinkTemplate.subject">Subject Line test</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} @rows={{3}} />
     </div>
   </div>
 </div>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -22,18 +22,18 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row d-none">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.subject">Subject Line test</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} @rows={{3}} />
+      <FormElements::Label @for="app.loginLinkTemplate.subject">Login Email Subject</FormElements::Label>
+      <Input @id="app.loginLinkTemplate.subject" @class="form-control" @value={{model.loginLinkTemplate.subject}} />
     </div>
   </div>
 </div>
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Unverified Verbiage</FormElements::Label>
+      <FormElements::Label @for="app.loginLinkTemplate.unverifiedVerbiage">Login Email Unverified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.unverifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.unverifiedVerbiage}} @rows={{3}} />
     </div>
   </div>
@@ -41,7 +41,7 @@
 <div class="row">
   <div class="col">
     <div class="form-group">
-      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Verified Verbiage</FormElements::Label>
+      <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Login Email Verified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
     </div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15335,6 +15335,11 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+striptags@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.2.0.tgz#cc74a137db2de8b0b9a370006334161f7dd67052"
+  integrity sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==
+
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"


### PR DESCRIPTION
Add the ability to override the verbiage that appears above the login link on a per app or appContext basis.  This will, have the ability to support simple html element like `<b>`, `<strong>`, `<em>`, `<i>`, `<u>`

For now the ability to subject line is there, but hidden behind a display: none class on the form row above the unverifed field

<img width="917" alt="Screen Shot 2023-07-11 at 1 22 08 PM" src="https://github.com/parameter1/identity-x/assets/3845869/50f6680c-1c64-4772-b2da-40f6f33d68ba">

<img width="917" alt="Screen Shot 2023-07-11 at 1 22 21 PM" src="https://github.com/parameter1/identity-x/assets/3845869/3a2b38d2-d26e-40fb-9f1e-e388397bea62">

### unverified
<img width="846" alt="Screen Shot 2023-07-11 at 1 40 26 PM" src="https://github.com/parameter1/identity-x/assets/3845869/7e8a9e68-e44e-4194-ad6c-8ecfb7257658">

### verified
<img width="704" alt="Screen Shot 2023-07-11 at 1 27 16 PM" src="https://github.com/parameter1/identity-x/assets/3845869/bc6d7b87-0edf-4bb3-840f-29491e95e63c">



