### PR TITLE
Set `approved: false` for comments with http(s) (including trailing slashes)

### DIFF
--- a/services/application/src/actions/comment/create.js
+++ b/services/application/src/actions/comment/create.js
@@ -43,7 +43,7 @@ module.exports = async ({
 
   const $ = cheerio.load(body);
 
-  const approved = !$('a, link').length;
+  const approved = !$('a, link').length && !body.match(/http(s?):\/\//);
   $('a, link').each(function fn() {
     this.attribs.rel = 'nofollow ugc';
   });


### PR DESCRIPTION
Opted to limit it here as it would prove difficult to determine beyond this of "URL-like" sub-strings without potentially just flagging everything.