### PR TITLE
Only update fields whose values are booleans, `customBooleanFields`

### DIFF
--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-boolean-fields.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-boolean-fields.js
@@ -28,7 +28,7 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
           id,
           answers: this.get('model.customBooleanFieldAnswers').reduce((array, answer) => {
             const { value, field } = answer;
-            return typeof value === 'boolean' ? [...array, { fieldId: field.id, value  }] : array;
+            return typeof value === 'boolean' ? [...array, { fieldId: field.id, value }] : array;
           }, [])
         };
         const variables = { input };

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-boolean-fields.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-boolean-fields.js
@@ -26,10 +26,10 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
         const id = this.get('model.id');
         const input = {
           id,
-          answers: this.get('model.customBooleanFieldAnswers').map((answer) => {
+          answers: this.get('model.customBooleanFieldAnswers').reduce((array, answer) => {
             const { value, field } = answer;
-            return { fieldId: field.id, value };
-          })
+            return typeof value === 'boolean' ? [...array, { fieldId: field.id, value  }] : array;
+          }, [])
         };
         const variables = { input };
         await this.mutate({ mutation, variables }, 'updateAppUserCustomBooleanAnswers');


### PR DESCRIPTION
This would cause erroring in cases by which the field goes entirely untouched and results a value of `null` over that of `false` or `true` due to the following: https://github.com/parameter1/identity-x/blob/master/services/graphql/src/graphql/definitions/app-user.js#L479