### PR TITLE
Add mutation to delete AppUsers for current Application

### DIFF
--- a/services/application/src/actions/user/delete-for-app.js
+++ b/services/application/src/actions/user/delete-for-app.js
@@ -1,0 +1,128 @@
+const { Types } = require('mongoose');
+const { tokenService } = require('@identity-x/service-clients');
+const { service } = require('@base-cms/micro');
+const models = require('../../mongodb/models');
+
+const { Application } = models;
+
+const { ObjectId } = Types;
+
+const { createRequiredParamError } = service;
+
+module.exports = async ({
+  applicationId,
+  email,
+  userId,
+} = {}) => {
+  if (!applicationId) throw createRequiredParamError('applicationId');
+
+  const pipeline = [
+    { $match: { _id: new ObjectId(applicationId) } },
+    { $group: { _id: null, appIds: { $push: '$_id' } } },
+    {
+      $lookup: {
+        from: 'app-users',
+        let: { appIds: '$appIds' },
+        as: 'appUser',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  {
+                    ...(email && { $eq: ['$email', email.toLowerCase()] }),
+                    ...(userId && { $eq: ['$_id', new ObjectId(userId)] }),
+                  },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { email: 1 } },
+        ],
+      },
+    },
+    { $unwind: '$appUser' },
+    {
+      $lookup: {
+        from: 'comments',
+        let: { appIds: '$appIds', appUserId: '$appUser._id' },
+        as: 'comments',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: ['$appUserId', '$$appUserId'] },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { _id: 1 } },
+        ],
+      },
+    },
+    {
+      $lookup: {
+        from: 'app-user-logins',
+        let: { appIds: '$appIds', email: '$appUser.email' },
+        as: 'appUserLogins',
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $and: [
+                  { $eq: ['$email', '$$email'] },
+                  { $in: ['$applicationId', '$$appIds'] },
+                ],
+              },
+            },
+          },
+          { $project: { _id: 1 } },
+        ],
+      },
+    },
+    {
+      $lookup: {
+        from: 'tokens',
+        let: { email: '$appUser.email' },
+        as: 'tokens',
+        pipeline: [
+          { $match: { $expr: { $eq: ['$payload.aud', '$$email'] } } },
+          { $project: { _id: 1, iss: 1 } },
+        ],
+      },
+    },
+  ];
+
+  const results = await Application.aggregate(pipeline);
+  const [doc] = results;
+
+  if (!doc) return false;
+  const stringifiedAppIds = new Set(doc.appIds.map(id => `${id}`));
+  const result = {
+    ...doc,
+    tokens: doc.tokens.filter(token => stringifiedAppIds.has(token.iss)),
+  };
+
+  const criterion = [
+    ['AppUser', { applicationId: { $in: result.appIds }, email: result.appUser.email }],
+    ['AppUserLogin', { _id: { $in: result.appUserLogins.map(login => login._id) } }],
+    ['Comment', { _id: { $in: result.comments.map(comment => comment._id) } }],
+  ];
+
+  await Promise.all([
+    Promise.all(criterion.map(async ([modelName, criteria]) => {
+      const Model = models[modelName];
+      await Model.deleteMany(criteria);
+    })),
+    (async () => {
+      const jtis = result.tokens.map(token => token._id);
+      if (!jtis.length) return;
+      await Promise.all(jtis.map(jti => tokenService.request('invalidate', { jti })));
+    })(),
+  ]);
+
+  return true;
+};

--- a/services/application/src/actions/user/delete-for-app.js
+++ b/services/application/src/actions/user/delete-for-app.js
@@ -15,7 +15,7 @@ module.exports = async ({
   userId,
 } = {}) => {
   if (!applicationId) throw createRequiredParamError('applicationId');
-  if (!email && !userId) throw createdRequiredParamError('email XOR userId');
+  if (!email && !userId) throw createRequiredParamError('email XOR userId');
 
   const pipeline = [
     { $match: { _id: new ObjectId(applicationId) } },

--- a/services/application/src/actions/user/delete-for-app.js
+++ b/services/application/src/actions/user/delete-for-app.js
@@ -15,6 +15,7 @@ module.exports = async ({
   userId,
 } = {}) => {
   if (!applicationId) throw createRequiredParamError('applicationId');
+  if (!email && !userId) throw createdRequiredParamError('email XOR userId');
 
   const pipeline = [
     { $match: { _id: new ObjectId(applicationId) } },

--- a/services/application/src/actions/user/index.js
+++ b/services/application/src/actions/user/index.js
@@ -9,6 +9,7 @@ const {
 const { createRequiredParamError } = require('@base-cms/micro').service;
 const changeEmail = require('./change-email');
 const create = require('./create');
+const deleteForApp = require('./delete-for-app');
 const deleteForOrg = require('./delete-for-org');
 const externalId = require('./external-id');
 const findByEmail = require('./find-by-email');
@@ -32,6 +33,7 @@ const AppUser = require('../../mongodb/models/app-user');
 module.exports = {
   changeEmail,
   create,
+  deleteForApp,
   deleteForOrg,
   externalId,
   findByEmail,

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -48,6 +48,8 @@ extend type Mutation {
   "Verifies and logs in the app user using their new email address."
   changeAppUserEmail(input: ChangeAppUserEmailMutationInput!): AppUserAuthentication! @requiresApp # must be public
 
+  deleteAppUserForCurrentApplication(input: DeleteAppUserForCurrentApplicationInput!): Boolean! @requiresAppRole(roles: [Owner, Administrator])
+
   deleteAppUserForCurrentOrg(input: DeleteAppUserForCurrentOrgInput!): Boolean! @requiresOrgRole(roles: [Owner, Administrator])
 }
 
@@ -293,6 +295,11 @@ input CreateAppUserMutationInput {
   street: String
   addressExtra: String
   phoneNumber: String
+}
+
+input DeleteAppUserForCurrentApplicationInput {
+  email: String
+  userId: ObjectID
 }
 
 input DeleteAppUserForCurrentOrgInput {

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -345,6 +345,22 @@ module.exports = {
       });
     },
 
+    deleteAppUserForCurrentApplication: (_, { input }, { app }) => {
+      const applicationId = app.getId();
+      const { email, userId } = input;
+      if (email && userId) {
+        throw new UserInputError('email XOR (exclusive or) userId is permitted!');
+      }
+      if (!email && !userId) {
+        throw new UserInputError('email XOR (exclusive or) userId is required!');
+      }
+      return applicationService.request('user.deleteForApp', {
+        applicationId,
+        email,
+        userId,
+      });
+    },
+
     deleteAppUserForCurrentOrg: (_, { input }, { org }) => {
       const organizationId = org.getId();
       const { email } = input;


### PR DESCRIPTION
Essentially identical to https://github.com/parameter1/identity-x/pull/38 except allows for either a `userId` or `email` to be submitted along with the `applicationId` in order to delete the specified user record should it exist.