### PR TITLE
Utilize `getAsArray` to ensure `customSelectFieldAnswers` is an array

### DIFF
--- a/services/application/src/mongodb/schema/app-user.js
+++ b/services/application/src/mongodb/schema/app-user.js
@@ -1,4 +1,5 @@
 const { Schema } = require('mongoose');
+const { getAsArray } = require('@base-cms/object-path');
 const { normalizeEmail } = require('@identity-x/utils');
 const { emailValidator, applicationPlugin, localePlugin } = require('@identity-x/mongoose-plugins');
 const { localeService } = require('@identity-x/service-clients');
@@ -220,7 +221,7 @@ schema.pre('save', async function setSegmentMembership() {
     rules.forEach((rule) => {
       const conditions = rule.conditions || [];
       if (conditions.every(({ field, answer }) => {
-        const f = this.customSelectFieldAnswers.find(a => `${a._id}` === `${field}`);
+        const f = getAsArray(this, 'customSelectFieldAnswers').find(a => `${a._id}` === `${field}`);
         if (!f) return false;
         return (f.values || []).includes(`${answer}`);
       })) {


### PR DESCRIPTION
Screenshot demonstrating this erroring previously:
![Screenshot from 2024-03-25 10-15-46](https://github.com/parameter1/identity-x/assets/46794001/e88942b4-bccc-491b-8815-7683b1729c3f)

This should correct this from happening and ensure that `this.customSelectFields` is always defined as an array and can be operated on as such.
