### PR TITLE
Allow for additionalContext to passed into login/authentication flow

### DIFF
--- a/services/application/src/actions/user/login.js
+++ b/services/application/src/actions/user/login.js
@@ -1,7 +1,6 @@
 const { get } = require('object-path');
 const { createError } = require('micro');
 const { createRequiredParamError } = require('@base-cms/micro').service;
-const { getAsObject } = require('@base-cms/object-path');
 const { tokenService } = require('@identity-x/service-clients');
 
 const { Application, AppUserLogin } = require('../../mongodb/models');
@@ -60,6 +59,6 @@ module.exports = async ({
     user: user.toObject(),
     token: { id: payload.jti, value: authToken },
     loginSource: get(data, 'source'),
-    additionalEventData: getAsObject(data, 'additionalEventData'),
+    additionalContext: data,
   };
 };

--- a/services/application/src/actions/user/login.js
+++ b/services/application/src/actions/user/login.js
@@ -1,6 +1,7 @@
 const { get } = require('object-path');
 const { createError } = require('micro');
 const { createRequiredParamError } = require('@base-cms/micro').service;
+const { getAsObject } = require('@base-cms/object-path');
 const { tokenService } = require('@identity-x/service-clients');
 
 const { Application, AppUserLogin } = require('../../mongodb/models');
@@ -59,5 +60,6 @@ module.exports = async ({
     user: user.toObject(),
     token: { id: payload.jti, value: authToken },
     loginSource: get(data, 'source'),
+    additionalEventData: getAsObject(data, 'additionalEventData'),
   };
 };

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -23,13 +23,13 @@ const createLoginToken = ({
 });
 
 module.exports = async ({
-  authUrl,
-  redirectTo,
-  applicationId,
+  additionalContext,
   appContextId,
-  source,
+  applicationId,
+  authUrl,
   email,
-  additionalEventData,
+  redirectTo,
+  source,
 } = {}) => {
   debug(authUrl, 'INCOMING AUTH URL');
   if (!authUrl) throw createRequiredParamError('authUrl');
@@ -65,7 +65,7 @@ module.exports = async ({
   const { token } = await createLoginToken({
     applicationId,
     email: user.email,
-    data: { source, additionalEventData },
+    data: { ...additionalContext, source },
   });
   let url = `${authUrl}?token=${token}`;
   if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;

--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -29,6 +29,7 @@ module.exports = async ({
   appContextId,
   source,
   email,
+  additionalEventData,
 } = {}) => {
   debug(authUrl, 'INCOMING AUTH URL');
   if (!authUrl) throw createRequiredParamError('authUrl');
@@ -61,7 +62,11 @@ module.exports = async ({
 
   if (supportEmail) addressValues.push(supportEmail);
 
-  const { token } = await createLoginToken({ applicationId, email: user.email, data: { source } });
+  const { token } = await createLoginToken({
+    applicationId,
+    email: user.email,
+    data: { source, additionalEventData },
+  });
   let url = `${authUrl}?token=${token}`;
   if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;
 

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -199,10 +199,11 @@ type AppUserEdge {
 }
 
 type AppUserAuthentication {
-  user: AppUser!
-  token: AppUserAuthToken!
+  "The additional context information returned from the token generated when login sent"
+  additionalContext: JSONObject
   loginSource: String
-  additionalEventData: JSONObject
+  token: AppUserAuthToken!
+  user: AppUser!
 }
 
 type AppUserAuthToken {
@@ -353,16 +354,16 @@ input SendOwnAppUserChangeEmailLinkMutationInput {
 }
 
 input SendAppUserLoginLinkMutationInput {
-  email: String!
-  source: String
-  authUrl: String!
-  redirectTo: String
   "If provided, will use the matched application context when sending the login email."
   appContextId: String
-  "If provided, will be used to append additional information to the login link token payload"
-  additionalEventData: JSONObject
+  "Additional contextual data to include in the login link token"
+  additionalContext: JSONObject
+  authUrl: String!
+  email: String!
   "Deprecated. While this field can still be sent, it is no longer used or handled."
   fields: JSON
+  redirectTo: String
+  source: String
 }
 
 input SetAppUserBannedMutationInput {

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -202,6 +202,7 @@ type AppUserAuthentication {
   user: AppUser!
   token: AppUserAuthToken!
   loginSource: String
+  additionalEventData: JSONObject
 }
 
 type AppUserAuthToken {
@@ -358,6 +359,8 @@ input SendAppUserLoginLinkMutationInput {
   redirectTo: String
   "If provided, will use the matched application context when sending the login email."
   appContextId: String
+  "If provided, will be used to append additional information to the login link token payload"
+  additionalEventData: JSONObject
   "Deprecated. While this field can still be sent, it is no longer used or handled."
   fields: JSON
 }

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -538,10 +538,10 @@ module.exports = {
         authUrl,
         redirectTo,
         appContextId,
-        additionalEventData,
+        additionalContext,
       } = input;
       return applicationService.request('user.sendLoginLink', {
-        additionalEventData,
+        additionalContext,
         applicationId,
         appContextId,
         authUrl,

--- a/services/graphql/src/graphql/resolvers/app-user.js
+++ b/services/graphql/src/graphql/resolvers/app-user.js
@@ -538,8 +538,10 @@ module.exports = {
         authUrl,
         redirectTo,
         appContextId,
+        additionalEventData,
       } = input;
       return applicationService.request('user.sendLoginLink', {
+        additionalEventData,
         applicationId,
         appContextId,
         authUrl,


### PR DESCRIPTION
This allows for the passthrough of a JSON object called `additionalContext`, this will allow for the `newsletterSignupType` (amongst other potential points of data) to be specified and returned namely for the login-link-click event tracking within P1 Events in order to enable correct event recording for reporting purposes.