### PR TITLE
Fix login link change, reset defaults & enable inputs in interface

### DIFF
--- a/services/application/src/actions/user/send-login-link.js
+++ b/services/application/src/actions/user/send-login-link.js
@@ -65,7 +65,13 @@ module.exports = async ({
   let url = `${authUrl}?token=${token}`;
   if (redirectTo) url = `${url}&redirectTo=${encodeURIComponent(redirectTo)}`;
 
-  const loginLinkTemplate = ['subject', 'unverifiedVerbiage', 'verifiedVerbiage'].reduce((o, key) => {
+  const loginLinkTemplate = [
+    'subject',
+    'unverifiedVerbiage',
+    'verifiedVerbiage',
+    'loginLinkStyle',
+    'loginLinkText',
+  ].reduce((o, key) => {
     const contextValue = context.loginLinkTemplate ? context.loginLinkTemplate[key] : null;
     return {
       ...o,

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -48,7 +48,7 @@ module.exports = ({
     text: `
 ${stripTags(verbiage, [])}
 
-Confrim & Log In:
+${btnText}:
 ${url}
 
 If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -16,8 +16,8 @@ module.exports = ({
   const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
-  const btnStyle = loginLinkTemplate.btnStyle ? loginLinkTemplate.btnStyle : '';
-  const btnText = loginLinkTemplate.btnText ? loginLinkTemplate.btnText : `Log in to ${appName}`;
+  const loginLinkStyle = loginLinkTemplate.loginLinkStyle ? loginLinkTemplate.loginLinkStyle : '';
+  const loginLinkText = loginLinkTemplate.loginLinkText ? loginLinkTemplate.loginLinkText : `Log in to ${appName}`;
   return ({
     html: `
     <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
@@ -31,9 +31,9 @@ module.exports = ({
       <body>
         <p>${verbiage}</p>
         <p>
-          <a href="${url}" style="${btnStyle}">
+          <a href="${url}" style="${loginLinkStyle}">
             <strong>
-              ${btnText}
+              ${loginLinkText}
             </strong>
           </a>
         </p>
@@ -50,7 +50,7 @@ module.exports = ({
     text: `
 ${stripTags(verbiage, [])}
 
-${btnText}:
+${loginLinkText}:
 ${url}
 
 If you didn't request this link, simply ignore this email or contact our support staff at ${supportEmail}.

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -16,6 +16,8 @@ module.exports = ({
   const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `You recently requested to log in to <strong>${appName}</strong>. This link is good for one hour.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
+  const btnStyle = loginLinkTemplate.btnStyle ? loginLinkTemplate.btnStyle : '';
+  const btnText = loginLinkTemplate.btnText ? loginLinkTemplate.btnText : `Log in to ${appName}`;
   return ({
     html: `
     <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
@@ -29,14 +31,8 @@ module.exports = ({
       <body>
         <p>${verbiage}</p>
         <p>
-          <a href="${url}">
-            <table border="0" cellspacing="0" cellpadding="0" style="background-color: #15c; color: #fff">
-              <tr>
-                <td style="padding: 8px;">
-                  <strong>Confirm + Log In</strong>
-                </td>
-              </tr>
-            </table>
+          <a href="${url}" style="${btnStyle}">
+            ${btnText}
           </a>
         </p>
         <p>If you didn't request this link, simply ignore this email${supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : ''}.</p>

--- a/services/application/src/email-templates/login-link/en-us.js
+++ b/services/application/src/email-templates/login-link/en-us.js
@@ -32,7 +32,9 @@ module.exports = ({
         <p>${verbiage}</p>
         <p>
           <a href="${url}" style="${btnStyle}">
-            ${btnText}
+            <strong>
+              ${btnText}
+            </strong>
           </a>
         </p>
         <p>If you didn't request this link, simply ignore this email${supportEmail ? ` or <a href="mailto:${supportEmail}">contact our support staff</a>` : ''}.</p>

--- a/services/application/src/email-templates/login-link/es-mx.js
+++ b/services/application/src/email-templates/login-link/es-mx.js
@@ -14,6 +14,8 @@ module.exports = ({
   const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
   const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
+  const btnStyle = loginLinkTemplate.btnStyle ? loginLinkTemplate.btnStyle : '';
+  const btnText = loginLinkTemplate.btnText ? loginLinkTemplate.btnText : `Iniciar sesión en ${appName}`;
   return ({
     html: `
     <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
@@ -26,7 +28,13 @@ module.exports = ({
       </head>
       <body>
         <p>${verbiage}</p>
-        <p><a href="${url}">Iniciar sesión en ${appName}</a></p>
+        <p>
+          <a href="${url}" style="${btnStyle}">
+            <strong>
+              ${btnText}
+            </strong>
+          </a>
+        </p>
         <p>Si no solicitó este enlace, simplemente ignore este correo electrónico${supportEmail ? ` o <a href="mailto:${supportEmail}">comuníquese con nuestro personal de soporte</a>` : ''}.</p>
         <hr>
         <small style="font-color: #ccc;">
@@ -40,7 +48,7 @@ module.exports = ({
     text: `
 ${stripTags(verbiage)}
 
-Iniciar sesión en ${appName}:
+${btnText}:
 ${url}
 
 Si no solicitó este enlace, simplemente ignore este correo electrónico${supportEmail ? ` o comuníquese con nuestro personal de soporte a ${supportEmail}` : ''}

--- a/services/application/src/email-templates/login-link/es-mx.js
+++ b/services/application/src/email-templates/login-link/es-mx.js
@@ -14,8 +14,8 @@ module.exports = ({
   const unverifiedVerbiage = loginLinkTemplate.unverifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
   const verifiedVerbiage = loginLinkTemplate.verifiedVerbiage || `Recientemente solicitó iniciar sesión en <strong>${appName}</strong>. Este enlace esta habilitado por una hora y caducará inmediatamente después de su uso.`;
   const verbiage = verified ? verifiedVerbiage : unverifiedVerbiage;
-  const btnStyle = loginLinkTemplate.btnStyle ? loginLinkTemplate.btnStyle : '';
-  const btnText = loginLinkTemplate.btnText ? loginLinkTemplate.btnText : `Iniciar sesión en ${appName}`;
+  const loginLinkStyle = loginLinkTemplate.loginLinkStyle ? loginLinkTemplate.loginLinkStyle : '';
+  const loginLinkText = loginLinkTemplate.loginLinkText ? loginLinkTemplate.loginLinkText : `Iniciar sesión en ${appName}`;
   return ({
     html: `
     <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
@@ -29,9 +29,9 @@ module.exports = ({
       <body>
         <p>${verbiage}</p>
         <p>
-          <a href="${url}" style="${btnStyle}">
+          <a href="${url}" style="${loginLinkStyle}">
             <strong>
-              ${btnText}
+              ${loginLinkText}
             </strong>
           </a>
         </p>
@@ -48,7 +48,7 @@ module.exports = ({
     text: `
 ${stripTags(verbiage)}
 
-${btnText}:
+${loginLinkText}:
 ${url}
 
 Si no solicitó este enlace, simplemente ignore este correo electrónico${supportEmail ? ` o comuníquese con nuestro personal de soporte a ${supportEmail}` : ''}

--- a/services/application/src/mongodb/schema/application.js
+++ b/services/application/src/mongodb/schema/application.js
@@ -25,6 +25,16 @@ const loginLinkTemplate = new Schema({
     trim: true,
     set: stripHtml,
   },
+  loginLinkStyle: {
+    type: String,
+    trim: true,
+    set: stripHtml,
+  },
+  loginLinkText: {
+    type: String,
+    trim: true,
+    set: stripHtml,
+  },
 });
 
 const contextSchema = new Schema({

--- a/services/graphql/src/graphql/definitions/application.js
+++ b/services/graphql/src/graphql/definitions/application.js
@@ -48,12 +48,16 @@ type LoginLinkTemplate {
   subject: String
   unverifiedVerbiage: String
   verifiedVerbiage: String
+  loginLinkStyle: String
+  loginLinkText: String
 }
 
 input LoginLinkTemplatePayloadInput {
   subject: String
   unverifiedVerbiage: String
   verifiedVerbiage: String
+  loginLinkStyle: String
+  loginLinkText: String
 }
 
 input AddApplicationContextMutationInput {

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/create.js
@@ -14,6 +14,8 @@ const mutation = gql`
         subject
         unverifiedVerbiage
         verifiedVerbiage
+        loginLinkStyle
+        loginLinkText
       }
       language
     }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit.js
@@ -14,6 +14,8 @@ const mutation = gql`
         subject
         unverifiedVerbiage
         verifiedVerbiage
+        loginLinkStyle
+        loginLinkText
       }
       description
       language

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/add.js
@@ -17,6 +17,8 @@ const mutation = gql`
           subject
           unverifiedVerbiage
           verifiedVerbiage
+          loginLinkStyle
+          loginLinkText
         }
         language
       }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/contexts/edit.js
@@ -17,6 +17,8 @@ const mutation = gql`
           subject
           unverifiedVerbiage
           verifiedVerbiage
+          loginLinkStyle
+          loginLinkText
         }
         language
       }

--- a/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/list/edit/index.js
@@ -15,6 +15,8 @@ const mutation = gql`
         subject
         unverifiedVerbiage
         verifiedVerbiage
+        loginLinkStyle
+        loginLinkText
       }
       language
     }

--- a/services/manage/app/mixins/action-mixin.js
+++ b/services/manage/app/mixins/action-mixin.js
@@ -26,11 +26,19 @@ export default Mixin.create(LoadingMixin, {
     this.hideLoading();
   },
 
-  formatLoginLinkTemplateInput({ subject, unverifiedVerbiage, verifiedVerbiage } = {}){
+  formatLoginLinkTemplateInput({
+    subject,
+    unverifiedVerbiage,
+    verifiedVerbiage,
+    loginLinkStyle,
+    loginLinkText,
+  } = {}){
     return {
       subject,
       unverifiedVerbiage,
       verifiedVerbiage,
+      loginLinkStyle,
+      loginLinkText,
     };
   },
 

--- a/services/manage/app/routes/manage/orgs/view/apps.js
+++ b/services/manage/app/routes/manage/orgs/view/apps.js
@@ -12,6 +12,8 @@ const query = gql`
         subject
         unverifiedVerbiage
         verifiedVerbiage
+        loginLinkStyle
+        loginLinkText
       }
     }
   }

--- a/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/list/edit.js
@@ -13,6 +13,8 @@ const query = gql`
         subject
         unverifiedVerbiage
         verifiedVerbiage
+        loginLinkStyle
+        loginLinkText
       }
       language
       contexts {
@@ -24,6 +26,8 @@ const query = gql`
           subject
           unverifiedVerbiage
           verifiedVerbiage
+          loginLinkStyle
+          loginLinkText
         }
         language
       }

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -22,7 +22,7 @@
     </div>
   </div>
 </div>
-<div class="row d-none">
+<div class="row">
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.subject">Login Email Subject</FormElements::Label>
@@ -43,6 +43,22 @@
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Login Email Verified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.loginLinkStyle">Login Email Link Style</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.loginLinkText">Login Email Link Text</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{3}} />
     </div>
   </div>
 </div>

--- a/services/manage/app/templates/components/application/context/fields.hbs
+++ b/services/manage/app/templates/components/application/context/fields.hbs
@@ -50,7 +50,7 @@
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.loginLinkStyle">Login Email Link Style</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{3}} />
+      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{1}} />
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.loginLinkText">Login Email Link Text</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{3}} />
+      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{1}} />
     </div>
   </div>
 </div>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -22,7 +22,7 @@
     </div>
   </div>
 </div>
-<div class="row d-none">
+<div class="row">
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.subject">Login Email Subject</FormElements::Label>
@@ -43,6 +43,22 @@
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.verifiedVerbiage">Login Email Verified Verbiage</FormElements::Label>
       <Textarea @id="app.loginLinkTemplate.verifiedVerbiage" @class="form-control" @value={{model.loginLinkTemplate.verifiedVerbiage}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.loginLinkStyle">Login Email Link Style</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{3}} />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col">
+    <div class="form-group">
+      <FormElements::Label @for="app.loginLinkTemplate.loginLinkText">Login Email Link Text</FormElements::Label>
+      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{3}} />
     </div>
   </div>
 </div>

--- a/services/manage/app/templates/components/application/modal-form/general-fields.hbs
+++ b/services/manage/app/templates/components/application/modal-form/general-fields.hbs
@@ -50,7 +50,7 @@
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.loginLinkStyle">Login Email Link Style</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{3}} />
+      <Textarea @id="app.loginLinkTemplate.loginLinkStyle" @class="form-control" @value={{model.loginLinkTemplate.loginLinkStyle}} @rows={{1}} />
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
   <div class="col">
     <div class="form-group">
       <FormElements::Label @for="app.loginLinkTemplate.loginLinkText">Login Email Link Text</FormElements::Label>
-      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{3}} />
+      <Textarea @id="app.loginLinkTemplate.loginLinkText" @class="form-control" @value={{model.loginLinkTemplate.loginLinkText}} @rows={{1}} />
     </div>
   </div>
 </div>


### PR DESCRIPTION
The interface will now display the three inputs as well: 
<img width="848" alt="Screenshot 2024-09-30 at 3 47 55 PM" src="https://github.com/user-attachments/assets/985fef84-53a8-4543-80fe-6fa36624c933">

resulting in: 
<img width="823" alt="Screenshot 2024-09-30 at 3 33 07 PM" src="https://github.com/user-attachments/assets/2c0d0b5e-35d2-427b-8a24-1dfb9cf82020">