### PR TITLE
Allow for forcibly unsetting answer(s) for custom selects

### DIFF
--- a/services/application/src/actions/user/update-custom-select-answers.js
+++ b/services/application/src/actions/user/update-custom-select-answers.js
@@ -28,8 +28,8 @@ module.exports = async ({
   }), {});
 
   const newAnswers = answers
-    // @todo: Check each existing/incoming value and ignore removals of inactive values
-    .filter(({ optionIds }) => optionIds.length) // ignore/unset fields without options
+    // Allow for optionIds to be empty if forceUnset is set to true
+    .filter(({ optionIds, forceUnset }) => optionIds.length || forceUnset)
     .map(item => ({ _id: item.fieldId, ...item }))
     .reduce((obj, { _id, optionIds, writeInValues }) => ({
       ...obj,

--- a/services/graphql/src/graphql/definitions/app-user.js
+++ b/services/graphql/src/graphql/definitions/app-user.js
@@ -547,6 +547,8 @@ input UpdateAppUserCustomSelectAnswer {
   optionIds: [String!]!
   "The write-in values for this field. This must always been an array, even if the question only supports one answer. An empty array will unset any existing write-ins."
   writeInValues: [UpdateAppUserCustomSelectAnswerWriteInValue!]
+  "Whether or not to forcibly unset the fieldId specified"
+  forceUnset: Boolean! = false
 }
 
 input UpdateAppUserCustomSelectAnswerWriteInValue {


### PR DESCRIPTION
Unanswered:
![Screenshot from 2024-12-02 12-33-45](https://github.com/user-attachments/assets/70db5b8a-db88-4cb3-b956-cb93289c6b75)

Answered:
![Screenshot from 2024-12-02 12-34-04](https://github.com/user-attachments/assets/9a700889-b81e-4ca1-85f5-aa07fcc42dc9)

Answer unset via utilizing SMG Identity-X endpoint with value set to UNSET:
![Screenshot from 2024-12-02 12-34-30](https://github.com/user-attachments/assets/6578e095-7cd9-4520-8582-b63ff54d185b)
