### PR TITLE
Account for `customBooleanFields` in export

### DIFF
--- a/services/export/src/actions/user/export-for-app.js
+++ b/services/export/src/actions/user/export-for-app.js
@@ -59,7 +59,18 @@ module.exports = async ({
       pagination: { limit: 500, sort: { field: 'name', order: 1 } },
     }),
   ]);
-  const customSelectFields = customFieldConnection.edges.map(edge => edge.node);
+  const { customSelectFields, customBooleanFields } = customFieldConnection.edges.reduce(
+    (object, edge) => {
+      // eslint-disable-next-line no-underscore-dangle
+      if (edge.node && edge.node._type === 'select') {
+        object.customSelectFields.push(edge.node);
+        // eslint-disable-next-line no-underscore-dangle
+      } else if (edge.node && edge.node._type === 'boolean') {
+        object.customBooleanFields.push(edge.node);
+      }
+      return object;
+    }, { customSelectFields: [], customBooleanFields: [] },
+  );
 
   try {
     const contents = await new Promise((resolve, reject) => {
@@ -77,6 +88,7 @@ module.exports = async ({
         limit: 10000,
         regionalConsentPolicies: getAsArray(org, 'regionalConsentPolicies'),
         customSelectFields,
+        customBooleanFields,
         params: {
           id: applicationId,
           sort: { field: 'createdAt', order: 'desc' },

--- a/services/export/src/utils/stream-results.js
+++ b/services/export/src/utils/stream-results.js
@@ -20,6 +20,7 @@ const executor = async (args) => {
     fields,
     regionalConsentPolicies,
     customSelectFields,
+    customBooleanFields,
     stream,
   } = args;
   const pagination = getAsObject(params, 'pagination');
@@ -55,8 +56,21 @@ const executor = async (args) => {
         : [];
       return { ...o, [rowLabel]: customSelect.multiple ? answeredOptions.join('|') : (answeredOptions[0] || '') };
     }, {});
+    const customBooleanAnswers = customBooleanFields.reduce((o, customBoolean) => {
+      let rowLabel = `Custom: ${customBoolean.name}`;
+      if (!customBoolean.active) rowLabel = `${rowLabel} [inactive]`;
+      const userAnswers = getAsArray(node, 'customBooleanFieldAnswers');
+      const fieldAnswer = userAnswers.find(answer => `${answer._id}` === `${customBoolean._id}`);
+      const { value } = fieldAnswer || { value: '' };
+      return { ...o, [rowLabel]: value };
+    }, {});
 
-    return { ...row, ...customSelectAnswers, ...answers };
+    return {
+      ...row,
+      ...customSelectAnswers,
+      ...customBooleanAnswers,
+      ...answers,
+    };
   });
   stream.push(JSON.stringify(nodes));
   const { hasNextPage, endCursor } = getAsObject(data, 'pageInfo');


### PR DESCRIPTION
Previously these were being lumped in with the custom selects and due to the JSON object format between the two being different would always result in the user answers for the boolean values to be blank, this will correct this to appropriately display true, false or blank as appropriate.