### PR TITLE
`canSelect` support

### DIFF
--- a/services/application/src/mongodb/schema/field/select.js
+++ b/services/application/src/mongodb/schema/field/select.js
@@ -38,7 +38,7 @@ const optionSchema = new Schema({
   /**
    * Whether or not the option is allowed to be selected
    */
-  selectableAnswer: {
+  canSelect: {
     type: Boolean,
     default: true,
   },

--- a/services/application/src/mongodb/schema/field/select.js
+++ b/services/application/src/mongodb/schema/field/select.js
@@ -34,6 +34,14 @@ const optionSchema = new Schema({
     type: Boolean,
     default: false,
   },
+
+  /**
+   * Whether or not the option is allowed to be selected
+   */
+  selectableAnswer: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const groupSchema = new Schema({

--- a/services/graphql/src/graphql/definitions/field.js
+++ b/services/graphql/src/graphql/definitions/field.js
@@ -174,6 +174,8 @@ type SelectFieldOption implements SelectFieldOptionChoice {
   externalIdentifier: String
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean
+  "Whether or not the option is allowed to be selected"
+  selectableAnswer: Boolean
   "The order of the option. When rendered, options and groups will be sorted using this value."
   index: Int!
 }
@@ -248,6 +250,8 @@ input CreateSelectFieldOptionInput {
   externalIdentifier: String
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean = false
+  "Whether or not the option is allowed to be selected"
+  selectableAnswer: Boolean = true
 }
 
 input CreateTextFieldMutationInput {
@@ -376,6 +380,8 @@ input UpdateSelectFieldOptionInput {
   externalIdentifier: String
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean
+  "Whether or not the option is allowed to be selected"
+  selectableAnswer: Boolean
   "The order of the option. When rendered, options and groups will be sorted using this value."
   index: Int = 0
 }

--- a/services/graphql/src/graphql/definitions/field.js
+++ b/services/graphql/src/graphql/definitions/field.js
@@ -175,7 +175,7 @@ type SelectFieldOption implements SelectFieldOptionChoice {
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean
   "Whether or not the option is allowed to be selected"
-  selectableAnswer: Boolean
+  canSelect: Boolean
   "The order of the option. When rendered, options and groups will be sorted using this value."
   index: Int!
 }
@@ -251,7 +251,7 @@ input CreateSelectFieldOptionInput {
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean = false
   "Whether or not the option is allowed to be selected"
-  selectableAnswer: Boolean = true
+  canSelect: Boolean = true
 }
 
 input CreateTextFieldMutationInput {
@@ -381,7 +381,7 @@ input UpdateSelectFieldOptionInput {
   "Whether free-form, write-in values are supported."
   canWriteIn: Boolean
   "Whether or not the option is allowed to be selected"
-  selectableAnswer: Boolean
+  canSelect: Boolean
   "The order of the option. When rendered, options and groups will be sorted using this value."
   index: Int = 0
 }

--- a/services/manage/app/components/custom-field/options.js
+++ b/services/manage/app/components/custom-field/options.js
@@ -36,7 +36,7 @@ export default Component.extend({
       this.choices.pushObject({
         label: '',
         index: this.get('index'),
-        selectableAnswer: true,
+        canSelect: true,
         __typename: 'SelectFieldOption',
       });
     },

--- a/services/manage/app/components/custom-field/options.js
+++ b/services/manage/app/components/custom-field/options.js
@@ -36,6 +36,7 @@ export default Component.extend({
       this.choices.pushObject({
         label: '',
         index: this.get('index'),
+        selectableAnswer: true,
         __typename: 'SelectFieldOption',
       });
     },

--- a/services/manage/app/components/custom-select-field.js
+++ b/services/manage/app/components/custom-select-field.js
@@ -23,6 +23,10 @@ export default Component.extend({
     return this.get('selected.canWriteIn') || this.get('selected.option.canWriteIn') || false;
   }),
 
+  selectableAnswer: computed('selected.{options.selectableAnswer}', function() {
+    return this.get('selected.option.selectableAnswer') || true;
+  }),
+
   /**
    * Use the selected answer as the option (when found) to ensure
    * selection highlighting is applied.

--- a/services/manage/app/components/custom-select-field.js
+++ b/services/manage/app/components/custom-select-field.js
@@ -23,8 +23,8 @@ export default Component.extend({
     return this.get('selected.canWriteIn') || this.get('selected.option.canWriteIn') || false;
   }),
 
-  selectableAnswer: computed('selected.{options.selectableAnswer}', function() {
-    return this.get('selected.option.selectableAnswer') || true;
+  canSelect: computed('selected.{options.canSelect}', function() {
+    return this.get('selected.option.canSelect') || true;
   }),
 
   /**

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
@@ -25,6 +25,7 @@ const mutation = gql`
         ... on SelectFieldOption {
           externalIdentifier
           canWriteIn
+          selectableAnswer
         }
         ... on SelectFieldOptionGroup {
           options {
@@ -106,6 +107,7 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
             label: option.label,
             externalIdentifier: option.externalIdentifier,
             canWriteIn: option.canWriteIn,
+            selectableAnswer: option.selectableAnswer,
           })),
           groups: groups.map((group) => ({
             id: group.id,
@@ -114,6 +116,7 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
             optionIds: group.options.map(option => option.id),
           })),
         };
+        console.log(options);
         if (!Object.keys(input.externalId).length) delete input.externalId;
         const variables = { input };
         await this.mutate({ mutation, variables }, 'updateSelectField');

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
@@ -25,7 +25,7 @@ const mutation = gql`
         ... on SelectFieldOption {
           externalIdentifier
           canWriteIn
-          selectableAnswer
+          canSelect
         }
         ... on SelectFieldOptionGroup {
           options {
@@ -107,7 +107,7 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
             label: option.label,
             externalIdentifier: option.externalIdentifier,
             canWriteIn: option.canWriteIn,
-            selectableAnswer: option.selectableAnswer,
+            canSelect: option.canSelect,
           })),
           groups: groups.map((group) => ({
             id: group.id,

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/fields/edit/select.js
@@ -116,7 +116,6 @@ export default Controller.extend(ActionMixin, AppQueryMixin, {
             optionIds: group.options.map(option => option.id),
           })),
         };
-        console.log(options);
         if (!Object.keys(input.externalId).length) delete input.externalId;
         const variables = { input };
         await this.mutate({ mutation, variables }, 'updateSelectField');

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
@@ -15,7 +15,7 @@ const mutation = gql`
           label
           option {
             canWriteIn
-            selectableAnswer
+            canSelect
           }
           writeInValue
         }

--- a/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
+++ b/services/manage/app/controllers/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
@@ -15,6 +15,7 @@ const mutation = gql`
           label
           option {
             canWriteIn
+            selectableAnswer
           }
           writeInValue
         }

--- a/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/select.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/select.js
@@ -24,6 +24,7 @@ const query = gql`
         ... on SelectFieldOption {
           externalIdentifier
           canWriteIn
+          selectableAnswer
         }
         ... on SelectFieldOptionGroup {
           options {
@@ -31,6 +32,7 @@ const query = gql`
             label
             index
             externalIdentifier
+            selectableAnswer
             canWriteIn
           }
         }
@@ -39,6 +41,7 @@ const query = gql`
         id
         label
         externalIdentifier
+        selectableAnswer
         canWriteIn
         index
       }

--- a/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/select.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/fields/edit/select.js
@@ -24,7 +24,7 @@ const query = gql`
         ... on SelectFieldOption {
           externalIdentifier
           canWriteIn
-          selectableAnswer
+          canSelect
         }
         ... on SelectFieldOptionGroup {
           options {
@@ -32,7 +32,7 @@ const query = gql`
             label
             index
             externalIdentifier
-            selectableAnswer
+            canSelect
             canWriteIn
           }
         }
@@ -41,7 +41,7 @@ const query = gql`
         id
         label
         externalIdentifier
-        selectableAnswer
+        canSelect
         canWriteIn
         index
       }

--- a/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
@@ -20,6 +20,7 @@ const query = gql`
             label
             ... on SelectFieldOption {
               canWriteIn
+              selectableAnswer
             }
             ... on SelectFieldOptionGroup {
               options {

--- a/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
+++ b/services/manage/app/routes/manage/orgs/view/apps/view/users/edit/custom-select-fields.js
@@ -20,7 +20,7 @@ const query = gql`
             label
             ... on SelectFieldOption {
               canWriteIn
-              selectableAnswer
+              canSelect
             }
             ... on SelectFieldOptionGroup {
               options {

--- a/services/manage/app/templates/components/custom-field/option.hbs
+++ b/services/manage/app/templates/components/custom-field/option.hbs
@@ -33,6 +33,13 @@
 
       <div
         class="d-flex border border-secondary border-left-0 border-right-0"
+        title="Allow answer to be selected"
+      >
+        <FormElements::ToggleButton @value={{model.selectableAnswer}} @size="small" />
+      </div>
+
+      <div
+        class="d-flex border border-secondary border-left-0 border-right-0"
         title="Allow write-in values"
       >
         <FormElements::ToggleButton @value={{model.canWriteIn}} @size="small" />

--- a/services/manage/app/templates/components/custom-field/option.hbs
+++ b/services/manage/app/templates/components/custom-field/option.hbs
@@ -35,7 +35,7 @@
         class="d-flex border border-secondary border-left-0 border-right-0"
         title="Allow answer to be selected"
       >
-        <FormElements::ToggleButton @value={{model.selectableAnswer}} @size="small" />
+        <FormElements::ToggleButton @value={{model.canSelect}} @size="small" />
       </div>
 
       <div


### PR DESCRIPTION
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/25d9c26b-9191-411a-90b7-f72223d0e287" />


Unsure how this needs to be handled within the Identity-X UI, visibility is likely an issue as we can't remove it from the options list to show when a user has it already selected but we can prevent it from being selected in user facing application(s) (websites).